### PR TITLE
Add AG Grid with customer data

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "ag-grid-community": "^34.1.0",
         "ag-grid-react": "^34.1.0",
+        "dexie": "^4.0.11",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-icons": "^5.5.0"
@@ -2005,6 +2006,12 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dexie": {
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/dexie/-/dexie-4.0.11.tgz",
+      "integrity": "sha512-SOKO002EqlvBYYKQSew3iymBoN2EQ4BDw/3yprjh7kAfFzjBYkaMNa/pZvcA7HSWlcKSQb9XhPe3wKyQ0x4A8A==",
+      "license": "Apache-2.0"
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.192",

--- a/client/package.json
+++ b/client/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "ag-grid-community": "^34.1.0",
     "ag-grid-react": "^34.1.0",
+    "dexie": "^4.0.11",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-icons": "^5.5.0"

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,25 +1,50 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { AgGridReact } from 'ag-grid-react';
-import type { ColDef } from "ag-grid-community";
+import type { ColDef } from 'ag-grid-community';
 import 'ag-grid-community/styles/ag-grid.css';
 import 'ag-grid-community/styles/ag-theme-alpine.css';
 import { FaTh } from 'react-icons/fa';
 import { FiSettings, FiSearch, FiHelpCircle } from 'react-icons/fi';
 import './App.css';
 
-interface Customer {
-  id: number;
-  name: string;
-  city: string;
-  balance: number;
-}
+import { db, type Customer } from './db';
 
-const sampleData: Customer[] = [
-  { id: 10000, name: 'Trey Research', city: 'Seattle', balance: 3000 },
-  { id: 20000, name: 'Coho Winery', city: 'Redmond', balance: 2500 },
-  { id: 30000, name: 'Relecloud', city: 'Denver', balance: 1200 },
-  { id: 40000, name: 'A Datum Corporation', city: 'Chicago', balance: 4100 },
-  { id: 50000, name: 'Contoso Ltd.', city: 'Austin', balance: 980 },
+const sampleData: Omit<Customer, 'id'>[] = [
+  {
+    no: 10000,
+    name: 'Trey Research',
+    locationCode: 'SEA',
+    phoneNumber: '555-0100',
+    contact: 'Mark Hens',
+  },
+  {
+    no: 20000,
+    name: 'Coho Winery',
+    locationCode: 'RED',
+    phoneNumber: '555-0150',
+    contact: 'Cindy Fox',
+  },
+  {
+    no: 30000,
+    name: 'Relecloud',
+    locationCode: 'DEN',
+    phoneNumber: '555-0200',
+    contact: 'Keith Harris',
+  },
+  {
+    no: 40000,
+    name: 'A Datum Corporation',
+    locationCode: 'CHI',
+    phoneNumber: '555-0250',
+    contact: 'Sue Black',
+  },
+  {
+    no: 50000,
+    name: 'Contoso Ltd.',
+    locationCode: 'AUS',
+    phoneNumber: '555-0300',
+    contact: 'Steven White',
+  },
 ];
 
 function GlobalHeader() {
@@ -66,17 +91,26 @@ function ActionBar() {
 }
 
 export default function App() {
-  const [rowData] = useState(sampleData);
+  const [rowData, setRowData] = useState<Customer[]>([]);
   const [columnDefs] = useState<ColDef<Customer>[]>([
-    { field: 'id', headerName: 'No.' },
+    { field: 'no', headerName: 'No.' },
     { field: 'name', headerName: 'Name', flex: 1 },
-    { field: 'city', headerName: 'City' },
-    {
-      field: 'balance',
-      headerName: 'Balance',
-      valueFormatter: (p: { value: number }) => `$${p.value.toFixed(2)}`,
-    },
+    { field: 'locationCode', headerName: 'Location Code' },
+    { field: 'phoneNumber', headerName: 'Phone Number' },
+    { field: 'contact', headerName: 'Contact' },
   ]);
+
+  useEffect(() => {
+    async function load() {
+      const count = await db.customers.count();
+      if (count === 0) {
+        await db.customers.bulkAdd(sampleData);
+      }
+      const customers = await db.customers.toArray();
+      setRowData(customers);
+    }
+    load();
+  }, []);
 
   return (
     <div className="app-container">

--- a/client/src/db.ts
+++ b/client/src/db.ts
@@ -1,0 +1,24 @@
+import Dexie from 'dexie';
+import type { Table } from 'dexie';
+
+export interface Customer {
+  id?: number;
+  no: number;
+  name: string;
+  locationCode: string;
+  phoneNumber: string;
+  contact: string;
+}
+
+class AppDB extends Dexie {
+  customers!: Table<Customer, number>;
+
+  constructor() {
+    super('AppDB');
+    this.version(1).stores({
+      customers: '++id,no,name,locationCode,phoneNumber,contact',
+    });
+  }
+}
+
+export const db = new AppDB();


### PR DESCRIPTION
## Summary
- include Dexie to manage a small client DB
- seed DB with a Customers table
- show customers in AG Grid with columns No., Name, Location Code, Phone Number, Contact

## Testing
- `npx tsc -p client/tsconfig.app.json --noEmit`
- `npm run --prefix client lint`


------
https://chatgpt.com/codex/tasks/task_e_6889eab7a0a88322b19cb09881dcdb9b