### PR TITLE
Fix duplicate customers in grid

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -106,12 +106,14 @@ export default function App() {
 
   useEffect(() => {
     async function load() {
-      const count = await db.customers.count();
-      if (count === 0) {
-        await db.customers.bulkAdd(sampleData);
-      }
-      const customers = await db.customers.toArray();
-      setRowData(customers);
+      await db.transaction('rw', db.customers, async () => {
+        const count = await db.customers.count();
+        if (count === 0) {
+          await db.customers.bulkAdd(sampleData);
+        }
+        const customers = await db.customers.toArray();
+        setRowData(customers);
+      });
     }
     load();
   }, []);


### PR DESCRIPTION
## Summary
- prevent inserting demo customers twice in dev when `StrictMode` triggers double effects

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6889ed830dc88322b3291b8fdedecb00