### PR TITLE
Integrate Fluent UI controls

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -8,6 +8,7 @@
       "name": "client",
       "version": "0.0.0",
       "dependencies": {
+        "@fluentui/react-components": "^9.68.1",
         "ag-grid-community": "^34.1.0",
         "ag-grid-react": "^34.1.0",
         "dexie": "^4.0.11",
@@ -278,6 +279,15 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.2.tgz",
+      "integrity": "sha512-KHp2IflsnGywDjBWDkR9iEqiWSpc8GIi0lgTT3mOElT0PP1tG26P4tmFI2YvAdzgq9RGyoHZQEIEdZy6Ec5xCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.27.2",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
@@ -325,6 +335,21 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@ctrl/tinycolor": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@ctrl/tinycolor/-/tinycolor-3.6.1.tgz",
+      "integrity": "sha512-SITSV6aIXsuVNV3f3O0f2n/cgyEDWoSqtZMYiAmcsYHydcKrOz3gUxB/iXd/Qf08+IZX4KpgNbvUdMBmWz+kcA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@emotion/hash": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
+      "integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==",
+      "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.8",
@@ -922,6 +947,3115 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.3.tgz",
+      "integrity": "sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.10"
+      }
+    },
+    "node_modules/@floating-ui/devtools": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/devtools/-/devtools-0.2.1.tgz",
+      "integrity": "sha512-8PHJLbD6VhBh+LJ1uty/Bz30qs02NXCE5u8WpOhSewlYXUWl03GNXknr9AS2yaAWJEQaY27x7eByJs44gODBcw==",
+      "peerDependencies": {
+        "@floating-ui/dom": ">=1.5.4"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.3.tgz",
+      "integrity": "sha512-uZA413QEpNuhtb3/iIKoYMSK07keHPYeXF02Zhd6e213j+d1NamLix/mCLxBUDW/Gx52sPH2m+chlUsyaBs/Ag==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.3",
+        "@floating-ui/utils": "^0.2.10"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
+      "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
+      "license": "MIT"
+    },
+    "node_modules/@fluentui/keyboard-keys": {
+      "version": "9.0.8",
+      "resolved": "https://registry.npmjs.org/@fluentui/keyboard-keys/-/keyboard-keys-9.0.8.tgz",
+      "integrity": "sha512-iUSJUUHAyTosnXK8O2Ilbfxma+ZyZPMua5vB028Ys96z80v+LFwntoehlFsdH3rMuPsA8GaC1RE7LMezwPBPdw==",
+      "license": "MIT",
+      "dependencies": {
+        "@swc/helpers": "^0.5.1"
+      }
+    },
+    "node_modules/@fluentui/priority-overflow": {
+      "version": "9.1.15",
+      "resolved": "https://registry.npmjs.org/@fluentui/priority-overflow/-/priority-overflow-9.1.15.tgz",
+      "integrity": "sha512-/3jPBBq64hRdA416grVj+ZeMBUIaKZk2S5HiRg7CKCAV1JuyF84Do0rQI6ns8Vb9XOGuc4kurMcL/UEftoEVrg==",
+      "license": "MIT",
+      "dependencies": {
+        "@swc/helpers": "^0.5.1"
+      }
+    },
+    "node_modules/@fluentui/react-components": {
+      "version": "9.68.1",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-components/-/react-components-9.68.1.tgz",
+      "integrity": "sha512-DzgU05SS3h1zO/hymUSOWIiDyeAQS6vGL+cpgOPTIfUfKPry+69aj8ac7u5bN8FiS+WplYLhKXEjOY9s2W8LQg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-accordion": "^9.8.2",
+        "@fluentui/react-alert": "9.0.0-beta.124",
+        "@fluentui/react-aria": "^9.16.1",
+        "@fluentui/react-avatar": "^9.9.2",
+        "@fluentui/react-badge": "^9.4.2",
+        "@fluentui/react-breadcrumb": "^9.3.2",
+        "@fluentui/react-button": "^9.6.2",
+        "@fluentui/react-card": "^9.4.2",
+        "@fluentui/react-carousel": "^9.8.2",
+        "@fluentui/react-checkbox": "^9.5.2",
+        "@fluentui/react-color-picker": "^9.2.2",
+        "@fluentui/react-combobox": "^9.16.2",
+        "@fluentui/react-dialog": "^9.14.2",
+        "@fluentui/react-divider": "^9.4.2",
+        "@fluentui/react-drawer": "^9.9.2",
+        "@fluentui/react-field": "^9.4.2",
+        "@fluentui/react-image": "^9.3.2",
+        "@fluentui/react-infobutton": "9.0.0-beta.102",
+        "@fluentui/react-infolabel": "^9.4.2",
+        "@fluentui/react-input": "^9.7.2",
+        "@fluentui/react-label": "^9.3.2",
+        "@fluentui/react-link": "^9.6.2",
+        "@fluentui/react-list": "^9.4.1",
+        "@fluentui/react-menu": "^9.19.2",
+        "@fluentui/react-message-bar": "^9.6.2",
+        "@fluentui/react-motion": "^9.10.1",
+        "@fluentui/react-nav": "^9.3.2",
+        "@fluentui/react-overflow": "^9.5.2",
+        "@fluentui/react-persona": "^9.5.2",
+        "@fluentui/react-popover": "^9.12.2",
+        "@fluentui/react-portal": "^9.7.2",
+        "@fluentui/react-positioning": "^9.20.2",
+        "@fluentui/react-progress": "^9.4.2",
+        "@fluentui/react-provider": "^9.22.2",
+        "@fluentui/react-radio": "^9.5.2",
+        "@fluentui/react-rating": "^9.3.2",
+        "@fluentui/react-search": "^9.3.2",
+        "@fluentui/react-select": "^9.4.2",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-skeleton": "^9.4.2",
+        "@fluentui/react-slider": "^9.5.2",
+        "@fluentui/react-spinbutton": "^9.5.2",
+        "@fluentui/react-spinner": "^9.7.2",
+        "@fluentui/react-swatch-picker": "^9.4.2",
+        "@fluentui/react-switch": "^9.4.2",
+        "@fluentui/react-table": "^9.18.2",
+        "@fluentui/react-tabs": "^9.9.2",
+        "@fluentui/react-tabster": "^9.26.2",
+        "@fluentui/react-tag-picker": "^9.7.2",
+        "@fluentui/react-tags": "^9.7.2",
+        "@fluentui/react-teaching-popover": "^9.6.2",
+        "@fluentui/react-text": "^9.6.2",
+        "@fluentui/react-textarea": "^9.6.2",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-toast": "^9.6.2",
+        "@fluentui/react-toolbar": "^9.6.2",
+        "@fluentui/react-tooltip": "^9.8.2",
+        "@fluentui/react-tree": "^9.12.2",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@fluentui/react-virtualizer": "9.0.0-alpha.102",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-accordion": {
+      "version": "9.8.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-accordion/-/react-accordion-9.8.2.tgz",
+      "integrity": "sha512-SckLoChjxkFS1+Y64gR2hYBJrye0KcRZy0Bm5hnrkiGFB+bgDSZBaO7uDfRS6re2Z+0AbJ4A/SJ4Gw/1gs228Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-aria": "^9.16.1",
+        "@fluentui/react-context-selector": "^9.2.4",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.1.4",
+        "@fluentui/react-motion": "^9.10.1",
+        "@fluentui/react-motion-components-preview": "^0.8.1",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-tabster": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-accordion/node_modules/@fluentui/react-context-selector": {
+      "version": "9.2.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-context-selector/-/react-context-selector-9.2.4.tgz",
+      "integrity": "sha512-4QJjaBWoJSW+Vu6XRT0A9j3h2RGdXNUj9ur6ljdXwG13DoE69v03cDVF8GT3jiXWO3veNJntelI0BS99Qb5wzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.23.1",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0",
+        "scheduler": ">=0.19.0 <=0.23.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-accordion/node_modules/@fluentui/react-icons": {
+      "version": "2.0.307",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-icons/-/react-icons-2.0.307.tgz",
+      "integrity": "sha512-HSXrzQ6o+RWPnNy68EJN2M/Dh9LAJ8l5U9zWfwaFWDgktMF7dJxItyckA5BsH6inFisi6cqKtazsq9oZdAj32A==",
+      "license": "MIT",
+      "dependencies": {
+        "@griffel/react": "^1.0.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-accordion/node_modules/@fluentui/react-jsx-runtime": {
+      "version": "9.1.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-jsx-runtime/-/react-jsx-runtime-9.1.4.tgz",
+      "integrity": "sha512-VD1+vGFOF1F5TDx2+ghcstSltaT6OSmzuNz/9bGPn6CIX4e5+o6aIFWBlJcFvj4WiJS4d+l7d6uSwgJpqT4rhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.23.1",
+        "@swc/helpers": "^0.5.1",
+        "react-is": "^17.0.2"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-accordion/node_modules/@fluentui/react-motion-components-preview": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-motion-components-preview/-/react-motion-components-preview-0.8.1.tgz",
+      "integrity": "sha512-TeU3nNeOapIyLd15T3jBArEsdrsZoknW4U/RJv6dFOe0aV2IRQ86wnKbD8eVmXxc9cLQ1UoWxF549YfQwxyKKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-motion": "*",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-alert": {
+      "version": "9.0.0-beta.124",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-alert/-/react-alert-9.0.0-beta.124.tgz",
+      "integrity": "sha512-yFBo3B5H9hnoaXxlkuz8wRz04DEyQ+ElYA/p5p+Vojf19Zuta8DmFZZ6JtWdtxcdnnQ4LvAfC5OYYlzdReozPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-avatar": "^9.6.29",
+        "@fluentui/react-button": "^9.3.83",
+        "@fluentui/react-icons": "^2.0.239",
+        "@fluentui/react-jsx-runtime": "^9.0.39",
+        "@fluentui/react-tabster": "^9.21.5",
+        "@fluentui/react-theme": "^9.1.19",
+        "@fluentui/react-utilities": "^9.18.10",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-alert/node_modules/@fluentui/react-icons": {
+      "version": "2.0.307",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-icons/-/react-icons-2.0.307.tgz",
+      "integrity": "sha512-HSXrzQ6o+RWPnNy68EJN2M/Dh9LAJ8l5U9zWfwaFWDgktMF7dJxItyckA5BsH6inFisi6cqKtazsq9oZdAj32A==",
+      "license": "MIT",
+      "dependencies": {
+        "@griffel/react": "^1.0.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-alert/node_modules/@fluentui/react-jsx-runtime": {
+      "version": "9.1.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-jsx-runtime/-/react-jsx-runtime-9.1.4.tgz",
+      "integrity": "sha512-VD1+vGFOF1F5TDx2+ghcstSltaT6OSmzuNz/9bGPn6CIX4e5+o6aIFWBlJcFvj4WiJS4d+l7d6uSwgJpqT4rhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.23.1",
+        "@swc/helpers": "^0.5.1",
+        "react-is": "^17.0.2"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-aria": {
+      "version": "9.16.1",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-aria/-/react-aria-9.16.1.tgz",
+      "integrity": "sha512-ynKArTu3RyOWhAB+bZdmCZU/UfBbiF+Cw3Gyrt8Oc/Qw1FVgNzFgpMYcTpFVshYhpApKWxbNCJgqm6jsiO8W8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-jsx-runtime": "^9.1.4",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-tabster": "^9.26.2",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-aria/node_modules/@fluentui/react-jsx-runtime": {
+      "version": "9.1.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-jsx-runtime/-/react-jsx-runtime-9.1.4.tgz",
+      "integrity": "sha512-VD1+vGFOF1F5TDx2+ghcstSltaT6OSmzuNz/9bGPn6CIX4e5+o6aIFWBlJcFvj4WiJS4d+l7d6uSwgJpqT4rhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.23.1",
+        "@swc/helpers": "^0.5.1",
+        "react-is": "^17.0.2"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-avatar": {
+      "version": "9.9.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-avatar/-/react-avatar-9.9.2.tgz",
+      "integrity": "sha512-i0K9tDvfPfQLPV3HyoKGwFqFjvoCmMXcYn6uTyoWjqLvRPLLlWlXnB+2/WFXYFAtJ+hOH9t960lGD1FVq21UTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-badge": "^9.4.2",
+        "@fluentui/react-context-selector": "^9.2.4",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.1.4",
+        "@fluentui/react-popover": "^9.12.2",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-tabster": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-tooltip": "^9.8.2",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-avatar/node_modules/@fluentui/react-context-selector": {
+      "version": "9.2.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-context-selector/-/react-context-selector-9.2.4.tgz",
+      "integrity": "sha512-4QJjaBWoJSW+Vu6XRT0A9j3h2RGdXNUj9ur6ljdXwG13DoE69v03cDVF8GT3jiXWO3veNJntelI0BS99Qb5wzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.23.1",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0",
+        "scheduler": ">=0.19.0 <=0.23.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-avatar/node_modules/@fluentui/react-icons": {
+      "version": "2.0.307",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-icons/-/react-icons-2.0.307.tgz",
+      "integrity": "sha512-HSXrzQ6o+RWPnNy68EJN2M/Dh9LAJ8l5U9zWfwaFWDgktMF7dJxItyckA5BsH6inFisi6cqKtazsq9oZdAj32A==",
+      "license": "MIT",
+      "dependencies": {
+        "@griffel/react": "^1.0.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-avatar/node_modules/@fluentui/react-jsx-runtime": {
+      "version": "9.1.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-jsx-runtime/-/react-jsx-runtime-9.1.4.tgz",
+      "integrity": "sha512-VD1+vGFOF1F5TDx2+ghcstSltaT6OSmzuNz/9bGPn6CIX4e5+o6aIFWBlJcFvj4WiJS4d+l7d6uSwgJpqT4rhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.23.1",
+        "@swc/helpers": "^0.5.1",
+        "react-is": "^17.0.2"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-badge": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-badge/-/react-badge-9.4.2.tgz",
+      "integrity": "sha512-jCTHsfhIY5bHsvnw/uuhzlDQl4I//trEJTR7wgBhxWq3T50LOe0wCCBbh7ik+YAVregoXk59Y7J6oet1oJOhOA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.1.4",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-badge/node_modules/@fluentui/react-icons": {
+      "version": "2.0.307",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-icons/-/react-icons-2.0.307.tgz",
+      "integrity": "sha512-HSXrzQ6o+RWPnNy68EJN2M/Dh9LAJ8l5U9zWfwaFWDgktMF7dJxItyckA5BsH6inFisi6cqKtazsq9oZdAj32A==",
+      "license": "MIT",
+      "dependencies": {
+        "@griffel/react": "^1.0.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-badge/node_modules/@fluentui/react-jsx-runtime": {
+      "version": "9.1.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-jsx-runtime/-/react-jsx-runtime-9.1.4.tgz",
+      "integrity": "sha512-VD1+vGFOF1F5TDx2+ghcstSltaT6OSmzuNz/9bGPn6CIX4e5+o6aIFWBlJcFvj4WiJS4d+l7d6uSwgJpqT4rhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.23.1",
+        "@swc/helpers": "^0.5.1",
+        "react-is": "^17.0.2"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-breadcrumb": {
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-breadcrumb/-/react-breadcrumb-9.3.2.tgz",
+      "integrity": "sha512-aUW1YkXndCVHEklkEfrDmnK1mh1h1jPUs15hfbVD2sTFZTDuQzUKpykccSCxD8Mhp6+SRiFTFtFXa81DdTP75w==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-aria": "^9.16.1",
+        "@fluentui/react-button": "^9.6.2",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.1.4",
+        "@fluentui/react-link": "^9.6.2",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-tabster": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-breadcrumb/node_modules/@fluentui/react-icons": {
+      "version": "2.0.307",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-icons/-/react-icons-2.0.307.tgz",
+      "integrity": "sha512-HSXrzQ6o+RWPnNy68EJN2M/Dh9LAJ8l5U9zWfwaFWDgktMF7dJxItyckA5BsH6inFisi6cqKtazsq9oZdAj32A==",
+      "license": "MIT",
+      "dependencies": {
+        "@griffel/react": "^1.0.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-breadcrumb/node_modules/@fluentui/react-jsx-runtime": {
+      "version": "9.1.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-jsx-runtime/-/react-jsx-runtime-9.1.4.tgz",
+      "integrity": "sha512-VD1+vGFOF1F5TDx2+ghcstSltaT6OSmzuNz/9bGPn6CIX4e5+o6aIFWBlJcFvj4WiJS4d+l7d6uSwgJpqT4rhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.23.1",
+        "@swc/helpers": "^0.5.1",
+        "react-is": "^17.0.2"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-button": {
+      "version": "9.6.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-button/-/react-button-9.6.2.tgz",
+      "integrity": "sha512-xkr5x45cgDGp0EIjgnCspXxFOKNsCwrPnX1xaGQeRokWTgvlUdZhW5PrwMLb3MgOV+ZC3IMBgbaTx/Kqy36EcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-aria": "^9.16.1",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.1.4",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-tabster": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-button/node_modules/@fluentui/react-icons": {
+      "version": "2.0.307",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-icons/-/react-icons-2.0.307.tgz",
+      "integrity": "sha512-HSXrzQ6o+RWPnNy68EJN2M/Dh9LAJ8l5U9zWfwaFWDgktMF7dJxItyckA5BsH6inFisi6cqKtazsq9oZdAj32A==",
+      "license": "MIT",
+      "dependencies": {
+        "@griffel/react": "^1.0.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-button/node_modules/@fluentui/react-jsx-runtime": {
+      "version": "9.1.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-jsx-runtime/-/react-jsx-runtime-9.1.4.tgz",
+      "integrity": "sha512-VD1+vGFOF1F5TDx2+ghcstSltaT6OSmzuNz/9bGPn6CIX4e5+o6aIFWBlJcFvj4WiJS4d+l7d6uSwgJpqT4rhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.23.1",
+        "@swc/helpers": "^0.5.1",
+        "react-is": "^17.0.2"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-card": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-card/-/react-card-9.4.2.tgz",
+      "integrity": "sha512-h26PZR4D0MMBpooTl42ISe25WaxX4/Pf7MaT4Q/CJqq4YlWh2SkgNND/Y+aPBZqOsO8X1LVhEb+KMyeXJDZfTA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-jsx-runtime": "^9.1.4",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-tabster": "^9.26.2",
+        "@fluentui/react-text": "^9.6.2",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-card/node_modules/@fluentui/react-jsx-runtime": {
+      "version": "9.1.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-jsx-runtime/-/react-jsx-runtime-9.1.4.tgz",
+      "integrity": "sha512-VD1+vGFOF1F5TDx2+ghcstSltaT6OSmzuNz/9bGPn6CIX4e5+o6aIFWBlJcFvj4WiJS4d+l7d6uSwgJpqT4rhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.23.1",
+        "@swc/helpers": "^0.5.1",
+        "react-is": "^17.0.2"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-carousel": {
+      "version": "9.8.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-carousel/-/react-carousel-9.8.2.tgz",
+      "integrity": "sha512-y/r868WLDGn1rkKwI0V7RoVlYh3DbUWH1dakPO7H7AtqgKvAlOUDiDzwOHMiNA+b10U36fM4+cynjiMtiP8JoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-aria": "^9.16.1",
+        "@fluentui/react-button": "^9.6.2",
+        "@fluentui/react-context-selector": "^9.2.4",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.1.4",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-tabster": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-tooltip": "^9.8.2",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1",
+        "embla-carousel": "^8.5.1",
+        "embla-carousel-autoplay": "^8.5.1",
+        "embla-carousel-fade": "^8.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-carousel/node_modules/@fluentui/react-context-selector": {
+      "version": "9.2.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-context-selector/-/react-context-selector-9.2.4.tgz",
+      "integrity": "sha512-4QJjaBWoJSW+Vu6XRT0A9j3h2RGdXNUj9ur6ljdXwG13DoE69v03cDVF8GT3jiXWO3veNJntelI0BS99Qb5wzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.23.1",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0",
+        "scheduler": ">=0.19.0 <=0.23.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-carousel/node_modules/@fluentui/react-icons": {
+      "version": "2.0.307",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-icons/-/react-icons-2.0.307.tgz",
+      "integrity": "sha512-HSXrzQ6o+RWPnNy68EJN2M/Dh9LAJ8l5U9zWfwaFWDgktMF7dJxItyckA5BsH6inFisi6cqKtazsq9oZdAj32A==",
+      "license": "MIT",
+      "dependencies": {
+        "@griffel/react": "^1.0.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-carousel/node_modules/@fluentui/react-jsx-runtime": {
+      "version": "9.1.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-jsx-runtime/-/react-jsx-runtime-9.1.4.tgz",
+      "integrity": "sha512-VD1+vGFOF1F5TDx2+ghcstSltaT6OSmzuNz/9bGPn6CIX4e5+o6aIFWBlJcFvj4WiJS4d+l7d6uSwgJpqT4rhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.23.1",
+        "@swc/helpers": "^0.5.1",
+        "react-is": "^17.0.2"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-checkbox": {
+      "version": "9.5.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-checkbox/-/react-checkbox-9.5.2.tgz",
+      "integrity": "sha512-xb6apCPe2hHLIAdmZ8oHu6FQkc/tNG/MH69DvJ0r7muHCD/MqQUjsvi00BJcmLuPOCsbfIL9kzYtraGY4oLhMA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-field": "^9.4.2",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.1.4",
+        "@fluentui/react-label": "^9.3.2",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-tabster": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-checkbox/node_modules/@fluentui/react-icons": {
+      "version": "2.0.307",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-icons/-/react-icons-2.0.307.tgz",
+      "integrity": "sha512-HSXrzQ6o+RWPnNy68EJN2M/Dh9LAJ8l5U9zWfwaFWDgktMF7dJxItyckA5BsH6inFisi6cqKtazsq9oZdAj32A==",
+      "license": "MIT",
+      "dependencies": {
+        "@griffel/react": "^1.0.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-checkbox/node_modules/@fluentui/react-jsx-runtime": {
+      "version": "9.1.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-jsx-runtime/-/react-jsx-runtime-9.1.4.tgz",
+      "integrity": "sha512-VD1+vGFOF1F5TDx2+ghcstSltaT6OSmzuNz/9bGPn6CIX4e5+o6aIFWBlJcFvj4WiJS4d+l7d6uSwgJpqT4rhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.23.1",
+        "@swc/helpers": "^0.5.1",
+        "react-is": "^17.0.2"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-color-picker": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-color-picker/-/react-color-picker-9.2.2.tgz",
+      "integrity": "sha512-STR94ApqxR+nv6AS+9OX5gDd28fgl766deTz+9AodxI50UfEv+aWwL5ihiPSOzjc6ypTkdWZSV5s3Jr4w6iM5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@ctrl/tinycolor": "^3.3.4",
+        "@fluentui/react-context-selector": "^9.2.4",
+        "@fluentui/react-jsx-runtime": "^9.1.4",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-tabster": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-color-picker/node_modules/@fluentui/react-context-selector": {
+      "version": "9.2.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-context-selector/-/react-context-selector-9.2.4.tgz",
+      "integrity": "sha512-4QJjaBWoJSW+Vu6XRT0A9j3h2RGdXNUj9ur6ljdXwG13DoE69v03cDVF8GT3jiXWO3veNJntelI0BS99Qb5wzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.23.1",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0",
+        "scheduler": ">=0.19.0 <=0.23.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-color-picker/node_modules/@fluentui/react-jsx-runtime": {
+      "version": "9.1.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-jsx-runtime/-/react-jsx-runtime-9.1.4.tgz",
+      "integrity": "sha512-VD1+vGFOF1F5TDx2+ghcstSltaT6OSmzuNz/9bGPn6CIX4e5+o6aIFWBlJcFvj4WiJS4d+l7d6uSwgJpqT4rhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.23.1",
+        "@swc/helpers": "^0.5.1",
+        "react-is": "^17.0.2"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-combobox": {
+      "version": "9.16.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-combobox/-/react-combobox-9.16.2.tgz",
+      "integrity": "sha512-KbQ4xxeg9Bga+av/4sGWWUDJP6wzfSax5XkayAHNnPaXUJtmYOzigePVvqcsgbpmTsa+do+1vyTMy3mGWIeG1A==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-aria": "^9.16.1",
+        "@fluentui/react-context-selector": "^9.2.4",
+        "@fluentui/react-field": "^9.4.2",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.1.4",
+        "@fluentui/react-portal": "^9.7.2",
+        "@fluentui/react-positioning": "^9.20.2",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-tabster": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-combobox/node_modules/@fluentui/react-context-selector": {
+      "version": "9.2.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-context-selector/-/react-context-selector-9.2.4.tgz",
+      "integrity": "sha512-4QJjaBWoJSW+Vu6XRT0A9j3h2RGdXNUj9ur6ljdXwG13DoE69v03cDVF8GT3jiXWO3veNJntelI0BS99Qb5wzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.23.1",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0",
+        "scheduler": ">=0.19.0 <=0.23.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-combobox/node_modules/@fluentui/react-icons": {
+      "version": "2.0.307",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-icons/-/react-icons-2.0.307.tgz",
+      "integrity": "sha512-HSXrzQ6o+RWPnNy68EJN2M/Dh9LAJ8l5U9zWfwaFWDgktMF7dJxItyckA5BsH6inFisi6cqKtazsq9oZdAj32A==",
+      "license": "MIT",
+      "dependencies": {
+        "@griffel/react": "^1.0.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-combobox/node_modules/@fluentui/react-jsx-runtime": {
+      "version": "9.1.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-jsx-runtime/-/react-jsx-runtime-9.1.4.tgz",
+      "integrity": "sha512-VD1+vGFOF1F5TDx2+ghcstSltaT6OSmzuNz/9bGPn6CIX4e5+o6aIFWBlJcFvj4WiJS4d+l7d6uSwgJpqT4rhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.23.1",
+        "@swc/helpers": "^0.5.1",
+        "react-is": "^17.0.2"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-dialog": {
+      "version": "9.14.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-dialog/-/react-dialog-9.14.2.tgz",
+      "integrity": "sha512-LKXIpotkNKtoZ6yR2+OkMKTPjJ/MvfjeJJ0usVRxbx0E3YWSpeeuG3NRQsyQlbK1fK9cnd5N40Pz+qEMskmN/w==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-aria": "^9.16.1",
+        "@fluentui/react-context-selector": "^9.2.4",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.1.4",
+        "@fluentui/react-motion": "^9.10.1",
+        "@fluentui/react-motion-components-preview": "^0.8.1",
+        "@fluentui/react-portal": "^9.7.2",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-tabster": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-dialog/node_modules/@fluentui/react-context-selector": {
+      "version": "9.2.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-context-selector/-/react-context-selector-9.2.4.tgz",
+      "integrity": "sha512-4QJjaBWoJSW+Vu6XRT0A9j3h2RGdXNUj9ur6ljdXwG13DoE69v03cDVF8GT3jiXWO3veNJntelI0BS99Qb5wzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.23.1",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0",
+        "scheduler": ">=0.19.0 <=0.23.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-dialog/node_modules/@fluentui/react-icons": {
+      "version": "2.0.307",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-icons/-/react-icons-2.0.307.tgz",
+      "integrity": "sha512-HSXrzQ6o+RWPnNy68EJN2M/Dh9LAJ8l5U9zWfwaFWDgktMF7dJxItyckA5BsH6inFisi6cqKtazsq9oZdAj32A==",
+      "license": "MIT",
+      "dependencies": {
+        "@griffel/react": "^1.0.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-dialog/node_modules/@fluentui/react-jsx-runtime": {
+      "version": "9.1.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-jsx-runtime/-/react-jsx-runtime-9.1.4.tgz",
+      "integrity": "sha512-VD1+vGFOF1F5TDx2+ghcstSltaT6OSmzuNz/9bGPn6CIX4e5+o6aIFWBlJcFvj4WiJS4d+l7d6uSwgJpqT4rhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.23.1",
+        "@swc/helpers": "^0.5.1",
+        "react-is": "^17.0.2"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-dialog/node_modules/@fluentui/react-motion-components-preview": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-motion-components-preview/-/react-motion-components-preview-0.8.1.tgz",
+      "integrity": "sha512-TeU3nNeOapIyLd15T3jBArEsdrsZoknW4U/RJv6dFOe0aV2IRQ86wnKbD8eVmXxc9cLQ1UoWxF549YfQwxyKKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-motion": "*",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-divider": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-divider/-/react-divider-9.4.2.tgz",
+      "integrity": "sha512-+deTs9M/FswHSC2zUJU8YUniUx2IiUOnXdfpKd3/pK0caCF1cLA6Vrr36TdTCLBImJMQXj4dU7Gzoq9XCXacRw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-jsx-runtime": "^9.1.4",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-divider/node_modules/@fluentui/react-jsx-runtime": {
+      "version": "9.1.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-jsx-runtime/-/react-jsx-runtime-9.1.4.tgz",
+      "integrity": "sha512-VD1+vGFOF1F5TDx2+ghcstSltaT6OSmzuNz/9bGPn6CIX4e5+o6aIFWBlJcFvj4WiJS4d+l7d6uSwgJpqT4rhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.23.1",
+        "@swc/helpers": "^0.5.1",
+        "react-is": "^17.0.2"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-drawer": {
+      "version": "9.9.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-drawer/-/react-drawer-9.9.2.tgz",
+      "integrity": "sha512-K444nz3pMAsxJp1uTTB6cYfkH2+LxT7BvPsi6x5GN+vZI9Qglxq+MYp20tUm0sJXR0PrVzyzvbMz54d8ZjwVHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-dialog": "^9.14.2",
+        "@fluentui/react-jsx-runtime": "^9.1.4",
+        "@fluentui/react-motion": "^9.10.1",
+        "@fluentui/react-portal": "^9.7.2",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-tabster": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-drawer/node_modules/@fluentui/react-jsx-runtime": {
+      "version": "9.1.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-jsx-runtime/-/react-jsx-runtime-9.1.4.tgz",
+      "integrity": "sha512-VD1+vGFOF1F5TDx2+ghcstSltaT6OSmzuNz/9bGPn6CIX4e5+o6aIFWBlJcFvj4WiJS4d+l7d6uSwgJpqT4rhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.23.1",
+        "@swc/helpers": "^0.5.1",
+        "react-is": "^17.0.2"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-field": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-field/-/react-field-9.4.2.tgz",
+      "integrity": "sha512-11ayN4VoMiyX4U5/fi97AZV7UE587oUr0Uv7Pi02eGW2K0Hc/czf3UxRS1DTwwamVJPgIMHPiraF36b/X2oihg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-context-selector": "^9.2.4",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.1.4",
+        "@fluentui/react-label": "^9.3.2",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-field/node_modules/@fluentui/react-context-selector": {
+      "version": "9.2.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-context-selector/-/react-context-selector-9.2.4.tgz",
+      "integrity": "sha512-4QJjaBWoJSW+Vu6XRT0A9j3h2RGdXNUj9ur6ljdXwG13DoE69v03cDVF8GT3jiXWO3veNJntelI0BS99Qb5wzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.23.1",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0",
+        "scheduler": ">=0.19.0 <=0.23.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-field/node_modules/@fluentui/react-icons": {
+      "version": "2.0.307",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-icons/-/react-icons-2.0.307.tgz",
+      "integrity": "sha512-HSXrzQ6o+RWPnNy68EJN2M/Dh9LAJ8l5U9zWfwaFWDgktMF7dJxItyckA5BsH6inFisi6cqKtazsq9oZdAj32A==",
+      "license": "MIT",
+      "dependencies": {
+        "@griffel/react": "^1.0.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-field/node_modules/@fluentui/react-jsx-runtime": {
+      "version": "9.1.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-jsx-runtime/-/react-jsx-runtime-9.1.4.tgz",
+      "integrity": "sha512-VD1+vGFOF1F5TDx2+ghcstSltaT6OSmzuNz/9bGPn6CIX4e5+o6aIFWBlJcFvj4WiJS4d+l7d6uSwgJpqT4rhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.23.1",
+        "@swc/helpers": "^0.5.1",
+        "react-is": "^17.0.2"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-image": {
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-image/-/react-image-9.3.2.tgz",
+      "integrity": "sha512-pLn3Me4pWKZ6eCC74zjk0YOq4nPlCMM7Sql4Ee5uYyscAqpmkl2fue8fPOWT1tar8FI342KpDZWTYoUWWbiFcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-jsx-runtime": "^9.1.4",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-image/node_modules/@fluentui/react-jsx-runtime": {
+      "version": "9.1.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-jsx-runtime/-/react-jsx-runtime-9.1.4.tgz",
+      "integrity": "sha512-VD1+vGFOF1F5TDx2+ghcstSltaT6OSmzuNz/9bGPn6CIX4e5+o6aIFWBlJcFvj4WiJS4d+l7d6uSwgJpqT4rhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.23.1",
+        "@swc/helpers": "^0.5.1",
+        "react-is": "^17.0.2"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-infobutton": {
+      "version": "9.0.0-beta.102",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-infobutton/-/react-infobutton-9.0.0-beta.102.tgz",
+      "integrity": "sha512-3kA4F0Vga8Ds6JGlBajLCCDOo/LmPuS786Wg7ui4ZTDYVIMzy1yp2XuVcZniifBFvEp0HQCUoDPWUV0VI3FfzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-icons": "^2.0.237",
+        "@fluentui/react-jsx-runtime": "^9.0.36",
+        "@fluentui/react-label": "^9.1.68",
+        "@fluentui/react-popover": "^9.9.6",
+        "@fluentui/react-tabster": "^9.21.0",
+        "@fluentui/react-theme": "^9.1.19",
+        "@fluentui/react-utilities": "^9.18.7",
+        "@griffel/react": "^1.5.14",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-infobutton/node_modules/@fluentui/react-icons": {
+      "version": "2.0.307",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-icons/-/react-icons-2.0.307.tgz",
+      "integrity": "sha512-HSXrzQ6o+RWPnNy68EJN2M/Dh9LAJ8l5U9zWfwaFWDgktMF7dJxItyckA5BsH6inFisi6cqKtazsq9oZdAj32A==",
+      "license": "MIT",
+      "dependencies": {
+        "@griffel/react": "^1.0.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-infobutton/node_modules/@fluentui/react-jsx-runtime": {
+      "version": "9.1.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-jsx-runtime/-/react-jsx-runtime-9.1.4.tgz",
+      "integrity": "sha512-VD1+vGFOF1F5TDx2+ghcstSltaT6OSmzuNz/9bGPn6CIX4e5+o6aIFWBlJcFvj4WiJS4d+l7d6uSwgJpqT4rhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.23.1",
+        "@swc/helpers": "^0.5.1",
+        "react-is": "^17.0.2"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-infolabel": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-infolabel/-/react-infolabel-9.4.2.tgz",
+      "integrity": "sha512-yMS5WJZKIvvqJpLEYE1+xORwmwt15pkh6WHVdeOd5L4AUwd8YbjqyeuI54AMUPU2dLqNqSzcEMXXfmCVnbQmrg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.1.4",
+        "@fluentui/react-label": "^9.3.2",
+        "@fluentui/react-popover": "^9.12.2",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-tabster": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8.0 <19.0.0",
+        "@types/react-dom": ">=16.8.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.8.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-infolabel/node_modules/@fluentui/react-icons": {
+      "version": "2.0.307",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-icons/-/react-icons-2.0.307.tgz",
+      "integrity": "sha512-HSXrzQ6o+RWPnNy68EJN2M/Dh9LAJ8l5U9zWfwaFWDgktMF7dJxItyckA5BsH6inFisi6cqKtazsq9oZdAj32A==",
+      "license": "MIT",
+      "dependencies": {
+        "@griffel/react": "^1.0.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-infolabel/node_modules/@fluentui/react-jsx-runtime": {
+      "version": "9.1.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-jsx-runtime/-/react-jsx-runtime-9.1.4.tgz",
+      "integrity": "sha512-VD1+vGFOF1F5TDx2+ghcstSltaT6OSmzuNz/9bGPn6CIX4e5+o6aIFWBlJcFvj4WiJS4d+l7d6uSwgJpqT4rhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.23.1",
+        "@swc/helpers": "^0.5.1",
+        "react-is": "^17.0.2"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-input": {
+      "version": "9.7.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-input/-/react-input-9.7.2.tgz",
+      "integrity": "sha512-F8F1inTs3eNz+5GMDThgMmYhQyofEomAEVQnpzxvhhMwBbabMrA57Leh0xyVGGzYzl8o4GZqJxrBEzIkvfddtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-field": "^9.4.2",
+        "@fluentui/react-jsx-runtime": "^9.1.4",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-input/node_modules/@fluentui/react-jsx-runtime": {
+      "version": "9.1.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-jsx-runtime/-/react-jsx-runtime-9.1.4.tgz",
+      "integrity": "sha512-VD1+vGFOF1F5TDx2+ghcstSltaT6OSmzuNz/9bGPn6CIX4e5+o6aIFWBlJcFvj4WiJS4d+l7d6uSwgJpqT4rhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.23.1",
+        "@swc/helpers": "^0.5.1",
+        "react-is": "^17.0.2"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-label": {
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-label/-/react-label-9.3.2.tgz",
+      "integrity": "sha512-TVYXC/dG5ck6fI2tpt+krZv6vYDAqJajIuSdoTs1IWYyg0CkKQXpPWSP7ghrlsmWPF4BKiTfaGZw+DgIR4lOXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-jsx-runtime": "^9.1.4",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-label/node_modules/@fluentui/react-jsx-runtime": {
+      "version": "9.1.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-jsx-runtime/-/react-jsx-runtime-9.1.4.tgz",
+      "integrity": "sha512-VD1+vGFOF1F5TDx2+ghcstSltaT6OSmzuNz/9bGPn6CIX4e5+o6aIFWBlJcFvj4WiJS4d+l7d6uSwgJpqT4rhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.23.1",
+        "@swc/helpers": "^0.5.1",
+        "react-is": "^17.0.2"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-link": {
+      "version": "9.6.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-link/-/react-link-9.6.2.tgz",
+      "integrity": "sha512-X7IJsC3PSQ0Wt6ETIOWW1+ByNCR2paxE4U3SnPrslCAtV845f/isI61STXKmVCSnK8y8fnLqWIVuPqPhMfDJog==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-jsx-runtime": "^9.1.4",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-tabster": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-link/node_modules/@fluentui/react-jsx-runtime": {
+      "version": "9.1.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-jsx-runtime/-/react-jsx-runtime-9.1.4.tgz",
+      "integrity": "sha512-VD1+vGFOF1F5TDx2+ghcstSltaT6OSmzuNz/9bGPn6CIX4e5+o6aIFWBlJcFvj4WiJS4d+l7d6uSwgJpqT4rhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.23.1",
+        "@swc/helpers": "^0.5.1",
+        "react-is": "^17.0.2"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-list": {
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-list/-/react-list-9.4.1.tgz",
+      "integrity": "sha512-QR4MUulhSSaRmR5S3sRv64ca2KDYaA8c3OLTBcH1XhQYoPG8pgIrNSEiQlgkfn6ejUBtlv/imBbyG0qTHFKZZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-checkbox": "^9.5.2",
+        "@fluentui/react-context-selector": "^9.2.4",
+        "@fluentui/react-jsx-runtime": "^9.1.4",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-tabster": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8.0 <19.0.0",
+        "@types/react-dom": ">=16.8.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.8.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-list/node_modules/@fluentui/react-context-selector": {
+      "version": "9.2.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-context-selector/-/react-context-selector-9.2.4.tgz",
+      "integrity": "sha512-4QJjaBWoJSW+Vu6XRT0A9j3h2RGdXNUj9ur6ljdXwG13DoE69v03cDVF8GT3jiXWO3veNJntelI0BS99Qb5wzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.23.1",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0",
+        "scheduler": ">=0.19.0 <=0.23.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-list/node_modules/@fluentui/react-jsx-runtime": {
+      "version": "9.1.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-jsx-runtime/-/react-jsx-runtime-9.1.4.tgz",
+      "integrity": "sha512-VD1+vGFOF1F5TDx2+ghcstSltaT6OSmzuNz/9bGPn6CIX4e5+o6aIFWBlJcFvj4WiJS4d+l7d6uSwgJpqT4rhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.23.1",
+        "@swc/helpers": "^0.5.1",
+        "react-is": "^17.0.2"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-menu": {
+      "version": "9.19.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-menu/-/react-menu-9.19.2.tgz",
+      "integrity": "sha512-s17l5H8UE2bNDTzJ23LvnaUmpx5NioHTP0ZlKI7cvAXLHo+6KqAbBUOgXNi+jE6IsGOl4omM7gyn+A/WDG3lTw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-aria": "^9.16.1",
+        "@fluentui/react-context-selector": "^9.2.4",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.1.4",
+        "@fluentui/react-portal": "^9.7.2",
+        "@fluentui/react-positioning": "^9.20.2",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-tabster": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-menu/node_modules/@fluentui/react-context-selector": {
+      "version": "9.2.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-context-selector/-/react-context-selector-9.2.4.tgz",
+      "integrity": "sha512-4QJjaBWoJSW+Vu6XRT0A9j3h2RGdXNUj9ur6ljdXwG13DoE69v03cDVF8GT3jiXWO3veNJntelI0BS99Qb5wzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.23.1",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0",
+        "scheduler": ">=0.19.0 <=0.23.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-menu/node_modules/@fluentui/react-icons": {
+      "version": "2.0.307",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-icons/-/react-icons-2.0.307.tgz",
+      "integrity": "sha512-HSXrzQ6o+RWPnNy68EJN2M/Dh9LAJ8l5U9zWfwaFWDgktMF7dJxItyckA5BsH6inFisi6cqKtazsq9oZdAj32A==",
+      "license": "MIT",
+      "dependencies": {
+        "@griffel/react": "^1.0.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-menu/node_modules/@fluentui/react-jsx-runtime": {
+      "version": "9.1.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-jsx-runtime/-/react-jsx-runtime-9.1.4.tgz",
+      "integrity": "sha512-VD1+vGFOF1F5TDx2+ghcstSltaT6OSmzuNz/9bGPn6CIX4e5+o6aIFWBlJcFvj4WiJS4d+l7d6uSwgJpqT4rhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.23.1",
+        "@swc/helpers": "^0.5.1",
+        "react-is": "^17.0.2"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-message-bar": {
+      "version": "9.6.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-message-bar/-/react-message-bar-9.6.2.tgz",
+      "integrity": "sha512-FIQW808iX05OLVdk6a5ugTiwjs2YV/vMejhkAWWA8IKiqoET46qOyVJyoxushRE10we4nLlbUWkQhtGriG8IYw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-button": "^9.6.2",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.1.4",
+        "@fluentui/react-link": "^9.6.2",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1",
+        "react-transition-group": "^4.4.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8.0 <19.0.0",
+        "@types/react-dom": ">=16.8.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.8.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-message-bar/node_modules/@fluentui/react-icons": {
+      "version": "2.0.307",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-icons/-/react-icons-2.0.307.tgz",
+      "integrity": "sha512-HSXrzQ6o+RWPnNy68EJN2M/Dh9LAJ8l5U9zWfwaFWDgktMF7dJxItyckA5BsH6inFisi6cqKtazsq9oZdAj32A==",
+      "license": "MIT",
+      "dependencies": {
+        "@griffel/react": "^1.0.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-message-bar/node_modules/@fluentui/react-jsx-runtime": {
+      "version": "9.1.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-jsx-runtime/-/react-jsx-runtime-9.1.4.tgz",
+      "integrity": "sha512-VD1+vGFOF1F5TDx2+ghcstSltaT6OSmzuNz/9bGPn6CIX4e5+o6aIFWBlJcFvj4WiJS4d+l7d6uSwgJpqT4rhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.23.1",
+        "@swc/helpers": "^0.5.1",
+        "react-is": "^17.0.2"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-motion": {
+      "version": "9.10.1",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-motion/-/react-motion-9.10.1.tgz",
+      "integrity": "sha512-DMHRWzWoei4/FCV9ziQ9M4GkY8P24Ld8ouPjH5Eopurg/fGua2AOVDkm/sY2AdjsWSJ1oDGqS6xMXRYm/u6FtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8.0 <19.0.0",
+        "@types/react-dom": ">=16.8.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.8.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-nav": {
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-nav/-/react-nav-9.3.2.tgz",
+      "integrity": "sha512-b5xQUYVUHo3mTNRNkwZwTJ1PdOvb3OfpgCs7fdf9MZ59AbO+f0fE/mCjJZ932bOjyU1h/3lmvXuk2+YsWAa7ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-aria": "^9.16.1",
+        "@fluentui/react-button": "^9.6.2",
+        "@fluentui/react-context-selector": "^9.2.4",
+        "@fluentui/react-divider": "^9.4.2",
+        "@fluentui/react-drawer": "^9.9.2",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.1.4",
+        "@fluentui/react-motion": "^9.10.1",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-tabster": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-tooltip": "^9.8.2",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-nav/node_modules/@fluentui/react-context-selector": {
+      "version": "9.2.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-context-selector/-/react-context-selector-9.2.4.tgz",
+      "integrity": "sha512-4QJjaBWoJSW+Vu6XRT0A9j3h2RGdXNUj9ur6ljdXwG13DoE69v03cDVF8GT3jiXWO3veNJntelI0BS99Qb5wzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.23.1",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0",
+        "scheduler": ">=0.19.0 <=0.23.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-nav/node_modules/@fluentui/react-icons": {
+      "version": "2.0.307",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-icons/-/react-icons-2.0.307.tgz",
+      "integrity": "sha512-HSXrzQ6o+RWPnNy68EJN2M/Dh9LAJ8l5U9zWfwaFWDgktMF7dJxItyckA5BsH6inFisi6cqKtazsq9oZdAj32A==",
+      "license": "MIT",
+      "dependencies": {
+        "@griffel/react": "^1.0.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-nav/node_modules/@fluentui/react-jsx-runtime": {
+      "version": "9.1.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-jsx-runtime/-/react-jsx-runtime-9.1.4.tgz",
+      "integrity": "sha512-VD1+vGFOF1F5TDx2+ghcstSltaT6OSmzuNz/9bGPn6CIX4e5+o6aIFWBlJcFvj4WiJS4d+l7d6uSwgJpqT4rhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.23.1",
+        "@swc/helpers": "^0.5.1",
+        "react-is": "^17.0.2"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-overflow": {
+      "version": "9.5.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-overflow/-/react-overflow-9.5.2.tgz",
+      "integrity": "sha512-ROt3WCzaiQVuIopCjngtB5/suDrkTxplYSvpLDizK0+tK98+znUHXHunQO7zc8bX7/QNJvEdn7RfVrWTlZlZ3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/priority-overflow": "^9.1.15",
+        "@fluentui/react-context-selector": "^9.2.4",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-overflow/node_modules/@fluentui/react-context-selector": {
+      "version": "9.2.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-context-selector/-/react-context-selector-9.2.4.tgz",
+      "integrity": "sha512-4QJjaBWoJSW+Vu6XRT0A9j3h2RGdXNUj9ur6ljdXwG13DoE69v03cDVF8GT3jiXWO3veNJntelI0BS99Qb5wzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.23.1",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0",
+        "scheduler": ">=0.19.0 <=0.23.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-persona": {
+      "version": "9.5.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-persona/-/react-persona-9.5.2.tgz",
+      "integrity": "sha512-3z6qu535Z2TsjPVvE5fP7tIvW34u7PPsVVKY9mFda32fo9+FEv3TFBRgvf5e8gz4gO+/8HXR1zUIzvo0b61qQg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-avatar": "^9.9.2",
+        "@fluentui/react-badge": "^9.4.2",
+        "@fluentui/react-jsx-runtime": "^9.1.4",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-persona/node_modules/@fluentui/react-jsx-runtime": {
+      "version": "9.1.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-jsx-runtime/-/react-jsx-runtime-9.1.4.tgz",
+      "integrity": "sha512-VD1+vGFOF1F5TDx2+ghcstSltaT6OSmzuNz/9bGPn6CIX4e5+o6aIFWBlJcFvj4WiJS4d+l7d6uSwgJpqT4rhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.23.1",
+        "@swc/helpers": "^0.5.1",
+        "react-is": "^17.0.2"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-popover": {
+      "version": "9.12.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-popover/-/react-popover-9.12.2.tgz",
+      "integrity": "sha512-uWWybq/0qtzbbnRrTqgwBN3ethwXDarYHMygKZCLcflmrm6C2lyfxCZ5pjoqx5zZlv8TXIaQ2/jXhSQPPhMgog==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-aria": "^9.16.1",
+        "@fluentui/react-context-selector": "^9.2.4",
+        "@fluentui/react-jsx-runtime": "^9.1.4",
+        "@fluentui/react-portal": "^9.7.2",
+        "@fluentui/react-positioning": "^9.20.2",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-tabster": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-popover/node_modules/@fluentui/react-context-selector": {
+      "version": "9.2.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-context-selector/-/react-context-selector-9.2.4.tgz",
+      "integrity": "sha512-4QJjaBWoJSW+Vu6XRT0A9j3h2RGdXNUj9ur6ljdXwG13DoE69v03cDVF8GT3jiXWO3veNJntelI0BS99Qb5wzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.23.1",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0",
+        "scheduler": ">=0.19.0 <=0.23.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-popover/node_modules/@fluentui/react-jsx-runtime": {
+      "version": "9.1.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-jsx-runtime/-/react-jsx-runtime-9.1.4.tgz",
+      "integrity": "sha512-VD1+vGFOF1F5TDx2+ghcstSltaT6OSmzuNz/9bGPn6CIX4e5+o6aIFWBlJcFvj4WiJS4d+l7d6uSwgJpqT4rhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.23.1",
+        "@swc/helpers": "^0.5.1",
+        "react-is": "^17.0.2"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-portal": {
+      "version": "9.7.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-portal/-/react-portal-9.7.2.tgz",
+      "integrity": "sha512-UC12+PsfrtAB+WrT39A8l86Szu2SXh7CUOf6q7+lJ2AWDdt93cYNQOU4QuLotoDebGuXZW4xMiB6QHy0sUGFiw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-tabster": "^9.26.2",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1",
+        "use-disposable": "^1.0.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-portal/node_modules/use-disposable": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/use-disposable/-/use-disposable-1.0.4.tgz",
+      "integrity": "sha512-j83t6AMLWUyb5zwlTDqf6dP9LezM9R0yTbI/b6olmdaGtCKQUe9pgJWV6dRaaQLcozypjIEp4EmZr2DkZGKLSg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": ">=16.8.0 <19.0.0",
+        "@types/react-dom": ">=16.8.0 <19.0.0",
+        "react": ">=16.8.0 <19.0.0",
+        "react-dom": ">=16.8.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-positioning": {
+      "version": "9.20.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-positioning/-/react-positioning-9.20.2.tgz",
+      "integrity": "sha512-nqj9hVl26D75fK072wDG2reYKI+aJx4X6IeqxYiYAzXlz6gGJuRKqmQwSAYiy9y6vBrpwWj5QGMjEOlwkd42nw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/devtools": "0.2.1",
+        "@floating-ui/dom": "^1.6.12",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1",
+        "use-sync-external-store": "^1.2.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-progress": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-progress/-/react-progress-9.4.2.tgz",
+      "integrity": "sha512-ra7kKByfq+uIg330twi9aagqUkKKls35jC9Hth0k8txIvt3u9y7Qm28wZStP4EAxapJXs/4LfI+0ZwdPQguH2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-field": "^9.4.2",
+        "@fluentui/react-jsx-runtime": "^9.1.4",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-progress/node_modules/@fluentui/react-jsx-runtime": {
+      "version": "9.1.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-jsx-runtime/-/react-jsx-runtime-9.1.4.tgz",
+      "integrity": "sha512-VD1+vGFOF1F5TDx2+ghcstSltaT6OSmzuNz/9bGPn6CIX4e5+o6aIFWBlJcFvj4WiJS4d+l7d6uSwgJpqT4rhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.23.1",
+        "@swc/helpers": "^0.5.1",
+        "react-is": "^17.0.2"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-provider": {
+      "version": "9.22.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-provider/-/react-provider-9.22.2.tgz",
+      "integrity": "sha512-7/ZUluKMBb9sxlSi/r0n4nHcgfWW0Ph4ZkkAi8c4uFg7JSKJjR3a1Ii9Wqxs+veK9PdNzILe6EMRXj8MWje8HA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.1.4",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-tabster": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/core": "^1.16.0",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-provider/node_modules/@fluentui/react-icons": {
+      "version": "2.0.307",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-icons/-/react-icons-2.0.307.tgz",
+      "integrity": "sha512-HSXrzQ6o+RWPnNy68EJN2M/Dh9LAJ8l5U9zWfwaFWDgktMF7dJxItyckA5BsH6inFisi6cqKtazsq9oZdAj32A==",
+      "license": "MIT",
+      "dependencies": {
+        "@griffel/react": "^1.0.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-provider/node_modules/@fluentui/react-jsx-runtime": {
+      "version": "9.1.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-jsx-runtime/-/react-jsx-runtime-9.1.4.tgz",
+      "integrity": "sha512-VD1+vGFOF1F5TDx2+ghcstSltaT6OSmzuNz/9bGPn6CIX4e5+o6aIFWBlJcFvj4WiJS4d+l7d6uSwgJpqT4rhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.23.1",
+        "@swc/helpers": "^0.5.1",
+        "react-is": "^17.0.2"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-radio": {
+      "version": "9.5.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-radio/-/react-radio-9.5.2.tgz",
+      "integrity": "sha512-ny+odHLH6h0bl/x0wxT1/J9k93lxQb3UMrTppDNFN4QudomHJJCAuwIzYLHrehxU0Iz6a9BGcbBXyUqEZANvNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-field": "^9.4.2",
+        "@fluentui/react-jsx-runtime": "^9.1.4",
+        "@fluentui/react-label": "^9.3.2",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-tabster": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-radio/node_modules/@fluentui/react-jsx-runtime": {
+      "version": "9.1.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-jsx-runtime/-/react-jsx-runtime-9.1.4.tgz",
+      "integrity": "sha512-VD1+vGFOF1F5TDx2+ghcstSltaT6OSmzuNz/9bGPn6CIX4e5+o6aIFWBlJcFvj4WiJS4d+l7d6uSwgJpqT4rhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.23.1",
+        "@swc/helpers": "^0.5.1",
+        "react-is": "^17.0.2"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-rating": {
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-rating/-/react-rating-9.3.2.tgz",
+      "integrity": "sha512-TsrPYNZW57A8KhBjWxTyeyb/3qt9NG8ZmBy5QB9DXS7dykj02dJXOVVOT3+vRQk4aKZ17RxXYZXfZNYoYzlAnQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.1.4",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-tabster": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8.0 <19.0.0",
+        "@types/react-dom": ">=16.8.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.8.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-rating/node_modules/@fluentui/react-icons": {
+      "version": "2.0.307",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-icons/-/react-icons-2.0.307.tgz",
+      "integrity": "sha512-HSXrzQ6o+RWPnNy68EJN2M/Dh9LAJ8l5U9zWfwaFWDgktMF7dJxItyckA5BsH6inFisi6cqKtazsq9oZdAj32A==",
+      "license": "MIT",
+      "dependencies": {
+        "@griffel/react": "^1.0.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-rating/node_modules/@fluentui/react-jsx-runtime": {
+      "version": "9.1.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-jsx-runtime/-/react-jsx-runtime-9.1.4.tgz",
+      "integrity": "sha512-VD1+vGFOF1F5TDx2+ghcstSltaT6OSmzuNz/9bGPn6CIX4e5+o6aIFWBlJcFvj4WiJS4d+l7d6uSwgJpqT4rhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.23.1",
+        "@swc/helpers": "^0.5.1",
+        "react-is": "^17.0.2"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-search": {
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-search/-/react-search-9.3.2.tgz",
+      "integrity": "sha512-s2tvGeVGy6jdIEo3ezhzAg1CzvsaaspXgF/x9Ykapyjs9AiG78cWJ3/HAfZY6kajq9h47eTwYEkDTEORqdvajQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-input": "^9.7.2",
+        "@fluentui/react-jsx-runtime": "^9.1.4",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-search/node_modules/@fluentui/react-icons": {
+      "version": "2.0.307",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-icons/-/react-icons-2.0.307.tgz",
+      "integrity": "sha512-HSXrzQ6o+RWPnNy68EJN2M/Dh9LAJ8l5U9zWfwaFWDgktMF7dJxItyckA5BsH6inFisi6cqKtazsq9oZdAj32A==",
+      "license": "MIT",
+      "dependencies": {
+        "@griffel/react": "^1.0.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-search/node_modules/@fluentui/react-jsx-runtime": {
+      "version": "9.1.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-jsx-runtime/-/react-jsx-runtime-9.1.4.tgz",
+      "integrity": "sha512-VD1+vGFOF1F5TDx2+ghcstSltaT6OSmzuNz/9bGPn6CIX4e5+o6aIFWBlJcFvj4WiJS4d+l7d6uSwgJpqT4rhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.23.1",
+        "@swc/helpers": "^0.5.1",
+        "react-is": "^17.0.2"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-select": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-select/-/react-select-9.4.2.tgz",
+      "integrity": "sha512-ST5hoXjjN0RQMDtwlC85AKej+W+3ayx1a9v+YlkQX2lOh+6Sj3iABsETgPM01Se8YwJ4DCbkJ5B52FVxXzXuuA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-field": "^9.4.2",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.1.4",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-select/node_modules/@fluentui/react-icons": {
+      "version": "2.0.307",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-icons/-/react-icons-2.0.307.tgz",
+      "integrity": "sha512-HSXrzQ6o+RWPnNy68EJN2M/Dh9LAJ8l5U9zWfwaFWDgktMF7dJxItyckA5BsH6inFisi6cqKtazsq9oZdAj32A==",
+      "license": "MIT",
+      "dependencies": {
+        "@griffel/react": "^1.0.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-select/node_modules/@fluentui/react-jsx-runtime": {
+      "version": "9.1.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-jsx-runtime/-/react-jsx-runtime-9.1.4.tgz",
+      "integrity": "sha512-VD1+vGFOF1F5TDx2+ghcstSltaT6OSmzuNz/9bGPn6CIX4e5+o6aIFWBlJcFvj4WiJS4d+l7d6uSwgJpqT4rhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.23.1",
+        "@swc/helpers": "^0.5.1",
+        "react-is": "^17.0.2"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-shared-contexts": {
+      "version": "9.24.1",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-shared-contexts/-/react-shared-contexts-9.24.1.tgz",
+      "integrity": "sha512-gQmynczh226aiPTV8PyzpOlSX0QTOZt0DG7ok/Q53DLWqBkRqsmfMHCEKZcDnjnemizu1IzB01NiXjXtk3WKzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-theme": "^9.2.0",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-skeleton": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-skeleton/-/react-skeleton-9.4.2.tgz",
+      "integrity": "sha512-v3elD30iWnx2frIdvcZnnd8D62pWi2HmLP5JA7So/v4iJ+mAAfnvLKDzbs27rtGhO6qTptPROt5WmtnHUI8y0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-field": "^9.4.2",
+        "@fluentui/react-jsx-runtime": "^9.1.4",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-skeleton/node_modules/@fluentui/react-jsx-runtime": {
+      "version": "9.1.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-jsx-runtime/-/react-jsx-runtime-9.1.4.tgz",
+      "integrity": "sha512-VD1+vGFOF1F5TDx2+ghcstSltaT6OSmzuNz/9bGPn6CIX4e5+o6aIFWBlJcFvj4WiJS4d+l7d6uSwgJpqT4rhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.23.1",
+        "@swc/helpers": "^0.5.1",
+        "react-is": "^17.0.2"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-slider": {
+      "version": "9.5.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-slider/-/react-slider-9.5.2.tgz",
+      "integrity": "sha512-ZWoR+a+hLdbmjlH3WJNccH+yEjaeXVdZJT85v/OwrKIUoLdDHkCOPuW35lxuVd8slLlh7gBxRKC2aS1uP/83Iw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-field": "^9.4.2",
+        "@fluentui/react-jsx-runtime": "^9.1.4",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-tabster": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-slider/node_modules/@fluentui/react-jsx-runtime": {
+      "version": "9.1.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-jsx-runtime/-/react-jsx-runtime-9.1.4.tgz",
+      "integrity": "sha512-VD1+vGFOF1F5TDx2+ghcstSltaT6OSmzuNz/9bGPn6CIX4e5+o6aIFWBlJcFvj4WiJS4d+l7d6uSwgJpqT4rhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.23.1",
+        "@swc/helpers": "^0.5.1",
+        "react-is": "^17.0.2"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-spinbutton": {
+      "version": "9.5.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-spinbutton/-/react-spinbutton-9.5.2.tgz",
+      "integrity": "sha512-LKRNI2SbdiKL5u8m1DZCaamfJjlHh+a0VDbPvy6KWfORHtlUYhvbGf1CRLGHNNLtL40WgbEzZx9DeM6iv/kM/w==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-field": "^9.4.2",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.1.4",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-spinbutton/node_modules/@fluentui/react-icons": {
+      "version": "2.0.307",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-icons/-/react-icons-2.0.307.tgz",
+      "integrity": "sha512-HSXrzQ6o+RWPnNy68EJN2M/Dh9LAJ8l5U9zWfwaFWDgktMF7dJxItyckA5BsH6inFisi6cqKtazsq9oZdAj32A==",
+      "license": "MIT",
+      "dependencies": {
+        "@griffel/react": "^1.0.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-spinbutton/node_modules/@fluentui/react-jsx-runtime": {
+      "version": "9.1.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-jsx-runtime/-/react-jsx-runtime-9.1.4.tgz",
+      "integrity": "sha512-VD1+vGFOF1F5TDx2+ghcstSltaT6OSmzuNz/9bGPn6CIX4e5+o6aIFWBlJcFvj4WiJS4d+l7d6uSwgJpqT4rhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.23.1",
+        "@swc/helpers": "^0.5.1",
+        "react-is": "^17.0.2"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-spinner": {
+      "version": "9.7.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-spinner/-/react-spinner-9.7.2.tgz",
+      "integrity": "sha512-+5XFzqwfDrFhK8iJ1MDdYZ0wGHeGsFR5H9Iw58JyIxcNNFNkHIGZYLpHgM15wYHzLmheS4CzWUY1IT2Ifen3oQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-jsx-runtime": "^9.1.4",
+        "@fluentui/react-label": "^9.3.2",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-spinner/node_modules/@fluentui/react-jsx-runtime": {
+      "version": "9.1.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-jsx-runtime/-/react-jsx-runtime-9.1.4.tgz",
+      "integrity": "sha512-VD1+vGFOF1F5TDx2+ghcstSltaT6OSmzuNz/9bGPn6CIX4e5+o6aIFWBlJcFvj4WiJS4d+l7d6uSwgJpqT4rhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.23.1",
+        "@swc/helpers": "^0.5.1",
+        "react-is": "^17.0.2"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-swatch-picker": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-swatch-picker/-/react-swatch-picker-9.4.2.tgz",
+      "integrity": "sha512-vduek/Psaqll/bFO9XJ91YCnE+KXphOqTkYzBKf4aLYJBJys/IFi5sIrEGlaxDMpgg8BeExSHjit9vuCArGjaA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-context-selector": "^9.2.4",
+        "@fluentui/react-field": "^9.4.2",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.1.4",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-tabster": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8.0 <19.0.0",
+        "@types/react-dom": ">=16.8.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.8.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-swatch-picker/node_modules/@fluentui/react-context-selector": {
+      "version": "9.2.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-context-selector/-/react-context-selector-9.2.4.tgz",
+      "integrity": "sha512-4QJjaBWoJSW+Vu6XRT0A9j3h2RGdXNUj9ur6ljdXwG13DoE69v03cDVF8GT3jiXWO3veNJntelI0BS99Qb5wzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.23.1",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0",
+        "scheduler": ">=0.19.0 <=0.23.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-swatch-picker/node_modules/@fluentui/react-icons": {
+      "version": "2.0.307",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-icons/-/react-icons-2.0.307.tgz",
+      "integrity": "sha512-HSXrzQ6o+RWPnNy68EJN2M/Dh9LAJ8l5U9zWfwaFWDgktMF7dJxItyckA5BsH6inFisi6cqKtazsq9oZdAj32A==",
+      "license": "MIT",
+      "dependencies": {
+        "@griffel/react": "^1.0.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-swatch-picker/node_modules/@fluentui/react-jsx-runtime": {
+      "version": "9.1.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-jsx-runtime/-/react-jsx-runtime-9.1.4.tgz",
+      "integrity": "sha512-VD1+vGFOF1F5TDx2+ghcstSltaT6OSmzuNz/9bGPn6CIX4e5+o6aIFWBlJcFvj4WiJS4d+l7d6uSwgJpqT4rhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.23.1",
+        "@swc/helpers": "^0.5.1",
+        "react-is": "^17.0.2"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-switch": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-switch/-/react-switch-9.4.2.tgz",
+      "integrity": "sha512-u/E7UeRRUbe5RnHNdslois6eGV6AFqJpzau48EDokmyJmv9nHIjq8ckt32kRH1dNcUm0/6BsXS40Wg0dhLgS0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-field": "^9.4.2",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.1.4",
+        "@fluentui/react-label": "^9.3.2",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-tabster": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-switch/node_modules/@fluentui/react-icons": {
+      "version": "2.0.307",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-icons/-/react-icons-2.0.307.tgz",
+      "integrity": "sha512-HSXrzQ6o+RWPnNy68EJN2M/Dh9LAJ8l5U9zWfwaFWDgktMF7dJxItyckA5BsH6inFisi6cqKtazsq9oZdAj32A==",
+      "license": "MIT",
+      "dependencies": {
+        "@griffel/react": "^1.0.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-switch/node_modules/@fluentui/react-jsx-runtime": {
+      "version": "9.1.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-jsx-runtime/-/react-jsx-runtime-9.1.4.tgz",
+      "integrity": "sha512-VD1+vGFOF1F5TDx2+ghcstSltaT6OSmzuNz/9bGPn6CIX4e5+o6aIFWBlJcFvj4WiJS4d+l7d6uSwgJpqT4rhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.23.1",
+        "@swc/helpers": "^0.5.1",
+        "react-is": "^17.0.2"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-table": {
+      "version": "9.18.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-table/-/react-table-9.18.2.tgz",
+      "integrity": "sha512-7c2asNZIY/GeCCfymdvuo9BhTMj6RolEVSCZjSInUcbzADn+C8+AHBOuajEhS0YJW1OFC8x1VM+7f0DJj4Lt4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-aria": "^9.16.1",
+        "@fluentui/react-avatar": "^9.9.2",
+        "@fluentui/react-checkbox": "^9.5.2",
+        "@fluentui/react-context-selector": "^9.2.4",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.1.4",
+        "@fluentui/react-radio": "^9.5.2",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-tabster": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-table/node_modules/@fluentui/react-context-selector": {
+      "version": "9.2.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-context-selector/-/react-context-selector-9.2.4.tgz",
+      "integrity": "sha512-4QJjaBWoJSW+Vu6XRT0A9j3h2RGdXNUj9ur6ljdXwG13DoE69v03cDVF8GT3jiXWO3veNJntelI0BS99Qb5wzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.23.1",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0",
+        "scheduler": ">=0.19.0 <=0.23.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-table/node_modules/@fluentui/react-icons": {
+      "version": "2.0.307",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-icons/-/react-icons-2.0.307.tgz",
+      "integrity": "sha512-HSXrzQ6o+RWPnNy68EJN2M/Dh9LAJ8l5U9zWfwaFWDgktMF7dJxItyckA5BsH6inFisi6cqKtazsq9oZdAj32A==",
+      "license": "MIT",
+      "dependencies": {
+        "@griffel/react": "^1.0.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-table/node_modules/@fluentui/react-jsx-runtime": {
+      "version": "9.1.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-jsx-runtime/-/react-jsx-runtime-9.1.4.tgz",
+      "integrity": "sha512-VD1+vGFOF1F5TDx2+ghcstSltaT6OSmzuNz/9bGPn6CIX4e5+o6aIFWBlJcFvj4WiJS4d+l7d6uSwgJpqT4rhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.23.1",
+        "@swc/helpers": "^0.5.1",
+        "react-is": "^17.0.2"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-tabs": {
+      "version": "9.9.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-tabs/-/react-tabs-9.9.2.tgz",
+      "integrity": "sha512-7dOhz7NHoi4kcn0B+RcReOgGi776yy5chPborwZQOTLg/E94fGkUecj8TkCLZdEUBOTrSIPaaWRF6m4atl+UEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-context-selector": "^9.2.4",
+        "@fluentui/react-jsx-runtime": "^9.1.4",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-tabster": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-tabs/node_modules/@fluentui/react-context-selector": {
+      "version": "9.2.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-context-selector/-/react-context-selector-9.2.4.tgz",
+      "integrity": "sha512-4QJjaBWoJSW+Vu6XRT0A9j3h2RGdXNUj9ur6ljdXwG13DoE69v03cDVF8GT3jiXWO3veNJntelI0BS99Qb5wzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.23.1",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0",
+        "scheduler": ">=0.19.0 <=0.23.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-tabs/node_modules/@fluentui/react-jsx-runtime": {
+      "version": "9.1.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-jsx-runtime/-/react-jsx-runtime-9.1.4.tgz",
+      "integrity": "sha512-VD1+vGFOF1F5TDx2+ghcstSltaT6OSmzuNz/9bGPn6CIX4e5+o6aIFWBlJcFvj4WiJS4d+l7d6uSwgJpqT4rhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.23.1",
+        "@swc/helpers": "^0.5.1",
+        "react-is": "^17.0.2"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-tabster": {
+      "version": "9.26.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-tabster/-/react-tabster-9.26.2.tgz",
+      "integrity": "sha512-Go9wzXjhZEcejfiw1vFqgC06p/+fPxw5woPblmiXYUDjNByCY5iTx2vNv6gf+duFZqLDITVhsA0t5P9xdDLiLg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1",
+        "keyborg": "^2.6.0",
+        "tabster": "^8.5.5"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-tag-picker": {
+      "version": "9.7.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-tag-picker/-/react-tag-picker-9.7.2.tgz",
+      "integrity": "sha512-iXZUl1SXPbboJCtMiQjQUnd/sPxtvBRxuXREAvIa/OBHbVtlmo4Bmr4Om0UkM1Bqoaje0T3hlm2PcLr7u9I+Vw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-aria": "^9.16.1",
+        "@fluentui/react-combobox": "^9.16.2",
+        "@fluentui/react-context-selector": "^9.2.4",
+        "@fluentui/react-field": "^9.4.2",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.1.4",
+        "@fluentui/react-portal": "^9.7.2",
+        "@fluentui/react-positioning": "^9.20.2",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-tabster": "^9.26.2",
+        "@fluentui/react-tags": "^9.7.2",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-tag-picker/node_modules/@fluentui/react-context-selector": {
+      "version": "9.2.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-context-selector/-/react-context-selector-9.2.4.tgz",
+      "integrity": "sha512-4QJjaBWoJSW+Vu6XRT0A9j3h2RGdXNUj9ur6ljdXwG13DoE69v03cDVF8GT3jiXWO3veNJntelI0BS99Qb5wzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.23.1",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0",
+        "scheduler": ">=0.19.0 <=0.23.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-tag-picker/node_modules/@fluentui/react-icons": {
+      "version": "2.0.307",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-icons/-/react-icons-2.0.307.tgz",
+      "integrity": "sha512-HSXrzQ6o+RWPnNy68EJN2M/Dh9LAJ8l5U9zWfwaFWDgktMF7dJxItyckA5BsH6inFisi6cqKtazsq9oZdAj32A==",
+      "license": "MIT",
+      "dependencies": {
+        "@griffel/react": "^1.0.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-tag-picker/node_modules/@fluentui/react-jsx-runtime": {
+      "version": "9.1.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-jsx-runtime/-/react-jsx-runtime-9.1.4.tgz",
+      "integrity": "sha512-VD1+vGFOF1F5TDx2+ghcstSltaT6OSmzuNz/9bGPn6CIX4e5+o6aIFWBlJcFvj4WiJS4d+l7d6uSwgJpqT4rhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.23.1",
+        "@swc/helpers": "^0.5.1",
+        "react-is": "^17.0.2"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-tags": {
+      "version": "9.7.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-tags/-/react-tags-9.7.2.tgz",
+      "integrity": "sha512-QvyH1rRUCZSecj1NPZSzIMu7o+dnEPGBVkCXlwxryxb5yFGE0Dry7cBvh/n0SXND3sJD6RoaBIh3vngrgdwI+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-aria": "^9.16.1",
+        "@fluentui/react-avatar": "^9.9.2",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.1.4",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-tabster": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-tags/node_modules/@fluentui/react-icons": {
+      "version": "2.0.307",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-icons/-/react-icons-2.0.307.tgz",
+      "integrity": "sha512-HSXrzQ6o+RWPnNy68EJN2M/Dh9LAJ8l5U9zWfwaFWDgktMF7dJxItyckA5BsH6inFisi6cqKtazsq9oZdAj32A==",
+      "license": "MIT",
+      "dependencies": {
+        "@griffel/react": "^1.0.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-tags/node_modules/@fluentui/react-jsx-runtime": {
+      "version": "9.1.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-jsx-runtime/-/react-jsx-runtime-9.1.4.tgz",
+      "integrity": "sha512-VD1+vGFOF1F5TDx2+ghcstSltaT6OSmzuNz/9bGPn6CIX4e5+o6aIFWBlJcFvj4WiJS4d+l7d6uSwgJpqT4rhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.23.1",
+        "@swc/helpers": "^0.5.1",
+        "react-is": "^17.0.2"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-teaching-popover": {
+      "version": "9.6.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-teaching-popover/-/react-teaching-popover-9.6.2.tgz",
+      "integrity": "sha512-w5f/rQP6j/o2i7R6P08ZWI6lh3qKHFWRFI8H4eJ/gAw5l7hXUpL4jfRfvVSPqLCfXvGeHGUEkLDzIiPLFy66mA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-aria": "^9.16.1",
+        "@fluentui/react-button": "^9.6.2",
+        "@fluentui/react-context-selector": "^9.2.4",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.1.4",
+        "@fluentui/react-popover": "^9.12.2",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-tabster": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1",
+        "use-sync-external-store": "^1.2.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8.0 <19.0.0",
+        "@types/react-dom": ">=16.8.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.8.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-teaching-popover/node_modules/@fluentui/react-context-selector": {
+      "version": "9.2.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-context-selector/-/react-context-selector-9.2.4.tgz",
+      "integrity": "sha512-4QJjaBWoJSW+Vu6XRT0A9j3h2RGdXNUj9ur6ljdXwG13DoE69v03cDVF8GT3jiXWO3veNJntelI0BS99Qb5wzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.23.1",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0",
+        "scheduler": ">=0.19.0 <=0.23.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-teaching-popover/node_modules/@fluentui/react-icons": {
+      "version": "2.0.307",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-icons/-/react-icons-2.0.307.tgz",
+      "integrity": "sha512-HSXrzQ6o+RWPnNy68EJN2M/Dh9LAJ8l5U9zWfwaFWDgktMF7dJxItyckA5BsH6inFisi6cqKtazsq9oZdAj32A==",
+      "license": "MIT",
+      "dependencies": {
+        "@griffel/react": "^1.0.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-teaching-popover/node_modules/@fluentui/react-jsx-runtime": {
+      "version": "9.1.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-jsx-runtime/-/react-jsx-runtime-9.1.4.tgz",
+      "integrity": "sha512-VD1+vGFOF1F5TDx2+ghcstSltaT6OSmzuNz/9bGPn6CIX4e5+o6aIFWBlJcFvj4WiJS4d+l7d6uSwgJpqT4rhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.23.1",
+        "@swc/helpers": "^0.5.1",
+        "react-is": "^17.0.2"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-text": {
+      "version": "9.6.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-text/-/react-text-9.6.2.tgz",
+      "integrity": "sha512-gBUV3jvTdKmvXkRU2s9vsFWIBP2Ukx+BAalR+vgJM2wibVYFAgHPVDw2/Sojjl7NxzgHDAD2dZdKegQR1AScZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-jsx-runtime": "^9.1.4",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-text/node_modules/@fluentui/react-jsx-runtime": {
+      "version": "9.1.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-jsx-runtime/-/react-jsx-runtime-9.1.4.tgz",
+      "integrity": "sha512-VD1+vGFOF1F5TDx2+ghcstSltaT6OSmzuNz/9bGPn6CIX4e5+o6aIFWBlJcFvj4WiJS4d+l7d6uSwgJpqT4rhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.23.1",
+        "@swc/helpers": "^0.5.1",
+        "react-is": "^17.0.2"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-textarea": {
+      "version": "9.6.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-textarea/-/react-textarea-9.6.2.tgz",
+      "integrity": "sha512-8sRTrrO0/iEVsA2OfINasG3eo5TVQ9br0vmm04zFZgtxKkEC9xtuJGLLHk3B6wbsmAST/JVl9k3xvkg1ES/Xqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-field": "^9.4.2",
+        "@fluentui/react-jsx-runtime": "^9.1.4",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-textarea/node_modules/@fluentui/react-jsx-runtime": {
+      "version": "9.1.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-jsx-runtime/-/react-jsx-runtime-9.1.4.tgz",
+      "integrity": "sha512-VD1+vGFOF1F5TDx2+ghcstSltaT6OSmzuNz/9bGPn6CIX4e5+o6aIFWBlJcFvj4WiJS4d+l7d6uSwgJpqT4rhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.23.1",
+        "@swc/helpers": "^0.5.1",
+        "react-is": "^17.0.2"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-toast": {
+      "version": "9.6.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-toast/-/react-toast-9.6.2.tgz",
+      "integrity": "sha512-c/pfw9sH51ntueM1JvCmJyi2oMiySdy/90cni1eUJtzXuE/8k7/Y+ndvMzgVvJ4XiV9zx2FhN35upNCXH6EXvg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-aria": "^9.16.1",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.1.4",
+        "@fluentui/react-motion": "^9.10.1",
+        "@fluentui/react-motion-components-preview": "^0.8.1",
+        "@fluentui/react-portal": "^9.7.2",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-tabster": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-toast/node_modules/@fluentui/react-icons": {
+      "version": "2.0.307",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-icons/-/react-icons-2.0.307.tgz",
+      "integrity": "sha512-HSXrzQ6o+RWPnNy68EJN2M/Dh9LAJ8l5U9zWfwaFWDgktMF7dJxItyckA5BsH6inFisi6cqKtazsq9oZdAj32A==",
+      "license": "MIT",
+      "dependencies": {
+        "@griffel/react": "^1.0.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-toast/node_modules/@fluentui/react-jsx-runtime": {
+      "version": "9.1.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-jsx-runtime/-/react-jsx-runtime-9.1.4.tgz",
+      "integrity": "sha512-VD1+vGFOF1F5TDx2+ghcstSltaT6OSmzuNz/9bGPn6CIX4e5+o6aIFWBlJcFvj4WiJS4d+l7d6uSwgJpqT4rhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.23.1",
+        "@swc/helpers": "^0.5.1",
+        "react-is": "^17.0.2"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-toast/node_modules/@fluentui/react-motion-components-preview": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-motion-components-preview/-/react-motion-components-preview-0.8.1.tgz",
+      "integrity": "sha512-TeU3nNeOapIyLd15T3jBArEsdrsZoknW4U/RJv6dFOe0aV2IRQ86wnKbD8eVmXxc9cLQ1UoWxF549YfQwxyKKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-motion": "*",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-toolbar": {
+      "version": "9.6.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-toolbar/-/react-toolbar-9.6.2.tgz",
+      "integrity": "sha512-sBQrofS7+06y8rDlwz/rLklPVOSLkxzcMlSJOoVCpEhp7YAIbNDx91IE7+rXXo+XGbq/8+wqlY0I4NhRkOrjCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-button": "^9.6.2",
+        "@fluentui/react-context-selector": "^9.2.4",
+        "@fluentui/react-divider": "^9.4.2",
+        "@fluentui/react-jsx-runtime": "^9.1.4",
+        "@fluentui/react-radio": "^9.5.2",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-tabster": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-toolbar/node_modules/@fluentui/react-context-selector": {
+      "version": "9.2.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-context-selector/-/react-context-selector-9.2.4.tgz",
+      "integrity": "sha512-4QJjaBWoJSW+Vu6XRT0A9j3h2RGdXNUj9ur6ljdXwG13DoE69v03cDVF8GT3jiXWO3veNJntelI0BS99Qb5wzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.23.1",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0",
+        "scheduler": ">=0.19.0 <=0.23.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-toolbar/node_modules/@fluentui/react-jsx-runtime": {
+      "version": "9.1.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-jsx-runtime/-/react-jsx-runtime-9.1.4.tgz",
+      "integrity": "sha512-VD1+vGFOF1F5TDx2+ghcstSltaT6OSmzuNz/9bGPn6CIX4e5+o6aIFWBlJcFvj4WiJS4d+l7d6uSwgJpqT4rhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.23.1",
+        "@swc/helpers": "^0.5.1",
+        "react-is": "^17.0.2"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-tooltip": {
+      "version": "9.8.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-tooltip/-/react-tooltip-9.8.2.tgz",
+      "integrity": "sha512-nqU4JqgkC50HYplmAWvNMSgemK8OFSlYqSurzGw9KAFTqddKlVjPmYochR6xzYq7Kpu1qfaCmaX/Nqz8rM30IA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-jsx-runtime": "^9.1.4",
+        "@fluentui/react-portal": "^9.7.2",
+        "@fluentui/react-positioning": "^9.20.2",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-tabster": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-tooltip/node_modules/@fluentui/react-jsx-runtime": {
+      "version": "9.1.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-jsx-runtime/-/react-jsx-runtime-9.1.4.tgz",
+      "integrity": "sha512-VD1+vGFOF1F5TDx2+ghcstSltaT6OSmzuNz/9bGPn6CIX4e5+o6aIFWBlJcFvj4WiJS4d+l7d6uSwgJpqT4rhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.23.1",
+        "@swc/helpers": "^0.5.1",
+        "react-is": "^17.0.2"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-tree": {
+      "version": "9.12.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-tree/-/react-tree-9.12.2.tgz",
+      "integrity": "sha512-NapMotRGp6q7UW0n2sEqWvXyg8C/xPMRM40CM1IW3kyswQAnlTwPP6cofph9iQyOSnc4lhgBEzzMAxXAsH4Onw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-aria": "^9.16.1",
+        "@fluentui/react-avatar": "^9.9.2",
+        "@fluentui/react-button": "^9.6.2",
+        "@fluentui/react-checkbox": "^9.5.2",
+        "@fluentui/react-context-selector": "^9.2.4",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.1.4",
+        "@fluentui/react-motion": "^9.10.1",
+        "@fluentui/react-motion-components-preview": "^0.8.1",
+        "@fluentui/react-radio": "^9.5.2",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-tabster": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.0",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-tree/node_modules/@fluentui/react-context-selector": {
+      "version": "9.2.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-context-selector/-/react-context-selector-9.2.4.tgz",
+      "integrity": "sha512-4QJjaBWoJSW+Vu6XRT0A9j3h2RGdXNUj9ur6ljdXwG13DoE69v03cDVF8GT3jiXWO3veNJntelI0BS99Qb5wzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.23.1",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0",
+        "scheduler": ">=0.19.0 <=0.23.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-tree/node_modules/@fluentui/react-icons": {
+      "version": "2.0.307",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-icons/-/react-icons-2.0.307.tgz",
+      "integrity": "sha512-HSXrzQ6o+RWPnNy68EJN2M/Dh9LAJ8l5U9zWfwaFWDgktMF7dJxItyckA5BsH6inFisi6cqKtazsq9oZdAj32A==",
+      "license": "MIT",
+      "dependencies": {
+        "@griffel/react": "^1.0.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-tree/node_modules/@fluentui/react-jsx-runtime": {
+      "version": "9.1.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-jsx-runtime/-/react-jsx-runtime-9.1.4.tgz",
+      "integrity": "sha512-VD1+vGFOF1F5TDx2+ghcstSltaT6OSmzuNz/9bGPn6CIX4e5+o6aIFWBlJcFvj4WiJS4d+l7d6uSwgJpqT4rhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.23.1",
+        "@swc/helpers": "^0.5.1",
+        "react-is": "^17.0.2"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-tree/node_modules/@fluentui/react-motion-components-preview": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-motion-components-preview/-/react-motion-components-preview-0.8.1.tgz",
+      "integrity": "sha512-TeU3nNeOapIyLd15T3jBArEsdrsZoknW4U/RJv6dFOe0aV2IRQ86wnKbD8eVmXxc9cLQ1UoWxF549YfQwxyKKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-motion": "*",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-utilities": {
+      "version": "9.23.1",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-utilities/-/react-utilities-9.23.1.tgz",
+      "integrity": "sha512-Vzxq4To9/HhfohYaZLcmSSSjLwn3bZ6HrlHHyCtv8jA28D5HtI9Xue3Xqy+nCshMSozwBxkrI7iWj9awmyUdQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-virtualizer": {
+      "version": "9.0.0-alpha.102",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-virtualizer/-/react-virtualizer-9.0.0-alpha.102.tgz",
+      "integrity": "sha512-kt/kuAMTKTTY/00ToUlgUwUCty2HGj4Tnr+fxKRmr7Ziy5VWhi1YoNJ8vcgmxog5J90t4tS29LB0LP0KztQUVg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-jsx-runtime": "^9.1.4",
+        "@fluentui/react-shared-contexts": "^9.24.1",
+        "@fluentui/react-utilities": "^9.23.1",
+        "@griffel/react": "^1.5.22",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "@types/react-dom": ">=16.9.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0",
+        "react-dom": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/@fluentui/react-virtualizer/node_modules/@fluentui/react-jsx-runtime": {
+      "version": "9.1.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-jsx-runtime/-/react-jsx-runtime-9.1.4.tgz",
+      "integrity": "sha512-VD1+vGFOF1F5TDx2+ghcstSltaT6OSmzuNz/9bGPn6CIX4e5+o6aIFWBlJcFvj4WiJS4d+l7d6uSwgJpqT4rhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.23.1",
+        "@swc/helpers": "^0.5.1",
+        "react-is": "^17.0.2"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <19.0.0",
+        "react": ">=16.14.0 <19.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "license": "MIT"
+    },
+    "node_modules/@fluentui/react-theme": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-theme/-/react-theme-9.2.0.tgz",
+      "integrity": "sha512-Q0zp/MY1m5RjlkcwMcjn/PQRT2T+q3bgxuxWbhgaD07V+tLzBhGROvuqbsdg4YWF/IK21zPfLhmGyifhEu0DnQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/tokens": "1.0.0-alpha.22",
+        "@swc/helpers": "^0.5.1"
+      }
+    },
+    "node_modules/@fluentui/tokens": {
+      "version": "1.0.0-alpha.22",
+      "resolved": "https://registry.npmjs.org/@fluentui/tokens/-/tokens-1.0.0-alpha.22.tgz",
+      "integrity": "sha512-i9fgYyyCWFRdUi+vQwnV6hp7wpLGK4p09B+O/f2u71GBXzPuniubPYvrIJYtl444DD6shLjYToJhQ1S6XTFwLg==",
+      "license": "MIT",
+      "dependencies": {
+        "@swc/helpers": "^0.5.1"
+      }
+    },
+    "node_modules/@griffel/core": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@griffel/core/-/core-1.19.2.tgz",
+      "integrity": "sha512-WkB/QQkjy9dE4vrNYGhQvRRUHFkYVOuaznVOMNTDT4pS9aTJ9XPrMTXXlkpcwaf0D3vNKoerj4zAwnU2lBzbOg==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/hash": "^0.9.0",
+        "@griffel/style-types": "^1.3.0",
+        "csstype": "^3.1.3",
+        "rtl-css-js": "^1.16.1",
+        "stylis": "^4.2.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@griffel/react": {
+      "version": "1.5.30",
+      "resolved": "https://registry.npmjs.org/@griffel/react/-/react-1.5.30.tgz",
+      "integrity": "sha512-1q4ojbEVFY5YA0j1NamP0WWF4BKh+GHsVugltDYeEgEaVbH3odJ7tJabuhQgY+7Nhka0pyEFWSiHJev0K3FSew==",
+      "license": "MIT",
+      "dependencies": {
+        "@griffel/core": "^1.19.2",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0 <20.0.0"
+      }
+    },
+    "node_modules/@griffel/style-types": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@griffel/style-types/-/style-types-1.3.0.tgz",
+      "integrity": "sha512-bHwD3sUE84Xwv4dH011gOKe1jul77M1S6ZFN9Tnq8pvZ48UMdY//vtES6fv7GRS5wXYT4iqxQPBluAiYAfkpmw==",
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.1.3"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -1360,6 +4494,15 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.17",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.17.tgz",
+      "integrity": "sha512-5IKx/Y13RsYd+sauPb2x+U/xZikHjolzfuDgTAl/Tdf3Q8rslRvC19NKDLgAJQ6wsqADk10ntlv08nPFw/gO/A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -1989,7 +5132,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -2023,12 +5165,46 @@
       "integrity": "sha512-SOKO002EqlvBYYKQSew3iymBoN2EQ4BDw/3yprjh7kAfFzjBYkaMNa/pZvcA7HSWlcKSQb9XhPe3wKyQ0x4A8A==",
       "license": "Apache-2.0"
     },
+    "node_modules/dom-helpers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.192",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.192.tgz",
       "integrity": "sha512-rP8Ez0w7UNw/9j5eSXCe10o1g/8B1P5SM90PCCMVkIRQn2R0LEHWz4Eh9RnxkniuDe1W0cTSOB3MLlkTGDcuCg==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/embla-carousel": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
+      "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
+      "license": "MIT"
+    },
+    "node_modules/embla-carousel-autoplay": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/embla-carousel-autoplay/-/embla-carousel-autoplay-8.6.0.tgz",
+      "integrity": "sha512-OBu5G3nwaSXkZCo1A6LTaFMZ8EpkYbwIaH+bPqdBnDGQ2fh4+NbzjXjs2SktoPNKCtflfVMc75njaDHOYXcrsA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "embla-carousel": "8.6.0"
+      }
+    },
+    "node_modules/embla-carousel-fade": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/embla-carousel-fade/-/embla-carousel-fade-8.6.0.tgz",
+      "integrity": "sha512-qaYsx5mwCz72ZrjlsXgs1nKejSrW+UhkbOMwLgfRT7w2LtdEB03nPRI06GHuHv5ac2USvbEiX2/nAHctcDwvpg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "embla-carousel": "8.6.0"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.25.8",
@@ -2609,6 +5785,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/keyborg": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/keyborg/-/keyborg-2.6.0.tgz",
+      "integrity": "sha512-o5kvLbuTF+o326CMVYpjlaykxqYP9DphFQZ2ZpgrvBouyvOxyEB7oqe8nOLFpiV5VCtz0D3pt8gXQYWpLpBnmA==",
+      "license": "MIT"
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -3026,6 +6208,22 @@
         "react-dom": ">=16.8"
       }
     },
+    "node_modules/react-transition-group": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0",
+        "react-dom": ">=16.6.0"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -3085,6 +6283,15 @@
         "@rollup/rollup-win32-ia32-msvc": "4.46.2",
         "@rollup/rollup-win32-x64-msvc": "4.46.2",
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rtl-css-js": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/rtl-css-js/-/rtl-css-js-1.16.1.tgz",
+      "integrity": "sha512-lRQgou1mu19e+Ya0LsTvKrVJ5TYUbqCVPAiImX3UfLTenarvPUl1QFdvu5Z3PYmHT9RCcwIfbjRQBntExyj3Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.1.2"
       }
     },
     "node_modules/run-parallel": {
@@ -3173,6 +6380,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/stylis": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.6.tgz",
+      "integrity": "sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==",
+      "license": "MIT"
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -3185,6 +6398,32 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/tabster": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/tabster/-/tabster-8.5.6.tgz",
+      "integrity": "sha512-2vfrRGrx8O9BjdrtSlVA5fvpmbq5HQBRN13XFRg6LAvZ1Fr3QdBnswgT4YgFS5Bhoo5nxwgjRaRueI2Us/dv7g==",
+      "license": "MIT",
+      "dependencies": {
+        "keyborg": "2.6.0",
+        "tslib": "^2.8.1"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-linux-x64-gnu": "4.40.0"
+      }
+    },
+    "node_modules/tabster/node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.40.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.40.0.tgz",
+      "integrity": "sha512-RcDGMtqF9EFN8i2RYN2W+64CdHruJ5rPqrlYw+cgM3uOVPSsnAQps7cpjXe9be/yDp8UC7VLoCoKC8J3Kn2FkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
     },
     "node_modules/tinyglobby": {
       "version": "0.2.14",
@@ -3256,6 +6495,12 @@
       "peerDependencies": {
         "typescript": ">=4.8.4"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -3347,6 +6592,15 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
+      "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/vite": {

--- a/client/package.json
+++ b/client/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@fluentui/react-components": "^9.68.1",
     "ag-grid-community": "^34.1.0",
     "ag-grid-react": "^34.1.0",
     "dexie": "^4.0.11",

--- a/client/src/CustomerCard.tsx
+++ b/client/src/CustomerCard.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Link, useParams } from 'react-router-dom';
-import { FiArrowLeft } from 'react-icons/fi';
+import { Input } from '@fluentui/react-components';
 import { db, type Customer } from './db';
 import { GlobalHeader, TopNav, ActionBar } from './components/Layout';
 import './App.css';
@@ -30,58 +30,58 @@ export default function CustomerCard() {
             <h3>General</h3>
             <label>
               No.
-              <input type="text" value={customer.no} readOnly />
+              <Input value={customer.no.toString()} readOnly style={{ width: 200 }} />
             </label>
             <label>
               Name
-              <input type="text" value={customer.name} readOnly />
+              <Input value={customer.name} readOnly style={{ width: 200 }} />
             </label>
           </div>
           <div className="section">
             <h3>Address and Contact</h3>
             <label>
               Address
-              <input type="text" value={customer.address ?? ''} readOnly />
+              <Input value={customer.address ?? ''} readOnly style={{ width: 200 }} />
             </label>
             <label>
               City
-              <input type="text" value={customer.city ?? ''} readOnly />
+              <Input value={customer.city ?? ''} readOnly style={{ width: 200 }} />
             </label>
             <label>
               State
-              <input type="text" value={customer.state ?? ''} readOnly />
+              <Input value={customer.state ?? ''} readOnly style={{ width: 200 }} />
             </label>
             <label>
               Zip Code
-              <input type="text" value={customer.zipCode ?? ''} readOnly />
+              <Input value={customer.zipCode ?? ''} readOnly style={{ width: 200 }} />
             </label>
             <label>
               Country
-              <input type="text" value={customer.country ?? ''} readOnly />
+              <Input value={customer.country ?? ''} readOnly style={{ width: 200 }} />
             </label>
             <label>
               Phone Number
-              <input type="text" value={customer.phoneNumber ?? ''} readOnly />
+              <Input value={customer.phoneNumber ?? ''} readOnly style={{ width: 200 }} />
             </label>
             <label>
               Mobile Phone Number
-              <input type="text" value={customer.mobilePhoneNumber ?? ''} readOnly />
+              <Input value={customer.mobilePhoneNumber ?? ''} readOnly style={{ width: 200 }} />
             </label>
             <label>
               Email
-              <input type="text" value={customer.email ?? ''} readOnly />
+              <Input value={customer.email ?? ''} readOnly style={{ width: 200 }} />
             </label>
             <label>
               Home Page
-              <input type="text" value={customer.homePage ?? ''} readOnly />
+              <Input value={customer.homePage ?? ''} readOnly style={{ width: 200 }} />
             </label>
             <label>
               Credit Limit
-              <input type="text" value={customer.creditLimit ?? ''} readOnly />
+              <Input value={(customer.creditLimit ?? '').toString()} readOnly style={{ width: 200 }} />
             </label>
             <label>
               Contact
-              <input type="text" value={customer.contact ?? ''} readOnly />
+              <Input value={customer.contact ?? ''} readOnly style={{ width: 200 }} />
             </label>
           </div>
           <div style={{ marginTop: '1em' }}>

--- a/client/src/CustomersPage.tsx
+++ b/client/src/CustomersPage.tsx
@@ -8,6 +8,7 @@ import 'ag-grid-community/styles/ag-theme-alpine.css';
 // Register AG Grid modules
 ModuleRegistry.registerModules([AllCommunityModule]);
 import { Link } from 'react-router-dom';
+import { Card } from '@fluentui/react-components';
 import { ActionBar, GlobalHeader, TopNav } from './components/Layout';
 import './App.css';
 
@@ -138,7 +139,7 @@ export default function CustomersPage() {
         </div>
         <div className="info-card">
           {[...Array(4)].map((_, i) => (
-            <div key={i} className="info-square" />
+            <Card key={i} className="info-square" />
           ))}
         </div>
       </div>

--- a/client/src/components/Layout.tsx
+++ b/client/src/components/Layout.tsx
@@ -6,6 +6,7 @@ import {
   FiPlus,
   FiTrash,
 } from 'react-icons/fi';
+import { Button } from '@fluentui/react-components';
 import '../App.css';
 
 export function GlobalHeader() {
@@ -44,15 +45,13 @@ export function ActionBar({ title }: { title: string }) {
       <div className="left-section">
         <span className="page-title">{title}</span>
         <div className="toolbar">
-          <button>
-            <FiPlus className="icon" />
-            <span>New</span>
-          </button>
-          <button>
-            <FiTrash className="icon" />
-            <span>Delete</span>
-          </button>
-          <button>Home</button>
+          <Button icon={<FiPlus />} appearance="secondary">
+            New
+          </Button>
+          <Button icon={<FiTrash />} appearance="secondary">
+            Delete
+          </Button>
+          <Button appearance="secondary">Home</Button>
         </div>
       </div>
     </div>

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,10 +1,13 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import './index.css'
-import App from './App.tsx'
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import { FluentProvider, webLightTheme } from '@fluentui/react-components';
+import './index.css';
+import App from './App.tsx';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <FluentProvider theme={webLightTheme}>
+      <App />
+    </FluentProvider>
   </StrictMode>,
-)
+);


### PR DESCRIPTION
## Summary
- add `@fluentui/react-components` dependency
- wrap app in `FluentProvider`
- replace toolbar and form inputs with Fluent `Button` and `Input`
- show cards with Fluent `Card`

## Testing
- `npm run lint`
- `NODE_OPTIONS=--max_old_space_size=4096 npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6889fe7bc8ac832282908e0c70d9d3e1